### PR TITLE
Moving us to Django 1.7 while it's easy

### DIFF
--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -6,6 +6,8 @@ import os
 import sys
 
 import yaml
+import django
+django.setup()
 
 from django.utils.text import slugify
 

--- a/foia_hub/views.py
+++ b/foia_hub/views.py
@@ -14,7 +14,6 @@ def request_form(request, slug=None):
     return HttpResponse(template.render(slug=slug))
 
 def request_start(request):
-
     template = env.get_template('request/index.html')
     return HttpResponse(template.render())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
-Django==1.6.5
+# Django, using
+Django==1.7
 psycopg2==2.5.3
 django-jinja==1.0.4
 django-jsonfield==0.9.13
 
 django-cors-headers
-
-#git+https://github.com/toastdriven/restless.git
 restless==2.0.1
 
 # PyYAML is for contact loading


### PR DESCRIPTION
This turned out to have just one tiny hiccup - you now have to include this at the top of things like scripts, to import the Django environment:

``` python
import django
django.setup()
```

This is not needed when running it as a management task, but it also doesn't hurt running it as a management task either.

Beyond that, everything seems to work just fine. However, as @khandelwal said, we, er, **really** need unit tests.
