### PR TITLE
Versions our nginx config as of right now

### DIFF
--- a/deploy/hub.conf
+++ b/deploy/hub.conf
@@ -1,0 +1,116 @@
+###
+#
+# nginx configuration for foia.18f.us and foia-proto.18f.us.
+#
+# For our SSL configuration (ssl.rules), please see
+# https://github.com/18f/ssl-standards
+#
+# NOTE: This nginx configuration is not currently synced automatically to version
+# control, so the deployed version may drift out of sync, though we'll try
+# not to let that happen.
+#
+###
+
+
+
+# Active development on FOIA hub, https://foia.18f.us
+server {
+    listen 443 ssl spdy;
+    server_name foia.18f.us;
+
+    ssl_certificate      /etc/nginx/ssl/keys/star.18f.us-chain.crt;
+    ssl_certificate_key  /etc/nginx/ssl/keys/star.18f.us.key;
+    include ssl/ssl.rules;
+
+    location / {
+
+        proxy_pass http://main_hub;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+
+        proxy_set_header Host   $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_max_temp_file_size 0;
+
+        proxy_connect_timeout 10;
+        proxy_send_timeout    30;
+        proxy_read_timeout    30;
+
+        access_log /home/foia/hub/shared/log/nginx_access.log;
+        error_log  /home/foia/hub/shared/log/nginx_error.log;
+
+    }
+
+    location /static/ {
+      autoindex off;
+      port_in_redirect off;
+      root /home/foia/hub/current/foia_hub/;
+      expires 1w;
+    }
+
+}
+
+# active development - lifecycle managed through fabric, primary server
+upstream main_hub {
+   server 127.0.0.1:8000;
+   keepalive 64;
+}
+
+# old prototype - not managed through fabric, not as important
+upstream proto_hub {
+  server 127.0.0.1:7000;
+  keepalive 64;
+}
+
+server {
+    listen 80;
+    server_name foia.18f.us;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 80;
+    server_name foia-proto.18f.us;
+    return 301 https://$host$request_uri;
+}
+
+# Old artifact of FOIA hub, https://foia-proto.18f.us
+server {
+    listen 443 ssl spdy;
+    server_name foia-proto.18f.us;
+
+    ssl_certificate      /etc/nginx/ssl/keys/star.18f.us-chain.crt;
+    ssl_certificate_key  /etc/nginx/ssl/keys/star.18f.us.key;
+    include ssl/ssl.rules;
+
+    location / {
+
+        proxy_pass http://proto_hub;
+        proxy_http_version 1.1;
+        proxy_redirect off;
+
+        proxy_set_header Host   $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_max_temp_file_size 0;
+
+        proxy_connect_timeout 10;
+        proxy_send_timeout    30;
+        proxy_read_timeout    30;
+
+        access_log /home/foia/hub/shared/log/proto-nginx_access.log;
+        error_log  /home/foia/hub/shared/log/proto-nginx_error.log;
+
+    }
+
+    location /static/ {
+      autoindex off;
+      port_in_redirect off;
+      root /home/foia/proto/foia_hub/;
+      expires 1w;
+    }
+
+}


### PR DESCRIPTION
This versions the app-specific part of our nginx config.

For the SSL configuration see [`ssl.rules`](https://github.com/18F/DevOps/blob/262c2114020de61148f84cab649c818bfd214e6c/nginx/ssl/ssl.rules) in our DevOps repo. (Soon to be moved into [ssl-standards](https://github.com/18f/ssl-standards).)
