### PR TITLE
Fixes /learn/, and adds a functional test to prevent regressions

### DIFF
--- a/foia_hub/tests/test_views.py
+++ b/foia_hub/tests/test_views.py
@@ -85,3 +85,8 @@ class RequestFormTests(SimpleTestCase):
         self.assertContains(response, self.agency.name)
         self.assertContains(response, self.office.name)
         self.assertNotContains(response, self.office2.name)
+
+    def test_learn(self):
+        """The /learn/ page should load without errors."""
+        response = self.client.get(reverse('learn'))
+        self.assertEqual(response.status_code, 200)

--- a/foia_hub/views.py
+++ b/foia_hub/views.py
@@ -26,7 +26,7 @@ def request_start(request):
     return HttpResponse(env.get_template('request/index.html').render())
 
 def learn(request):
-    return HttpResponse(env.get_template('request/learn.html').render())
+    return HttpResponse(env.get_template('learn.html').render())
 
 
 def request_success(request, id):


### PR DESCRIPTION
Basic unit test, points to the right template.

Tests: they're good.

(This was briefly committed directly to `master` as https://github.com/18F/foia-hub/commit/cee0f88f2e929af5ce6475f119d2f15015eadc98, and then reverted in https://github.com/18F/foia-hub/commit/a6e0c392b53269b6315a01051f81e9c0a96176fe. Mea culpa.)
