### PR TITLE
Refs #84: Adding field to store usa.gov id to make future updates easier...

### DIFF
--- a/foia_hub/migrations/0009_agency_usa_contact_id.py
+++ b/foia_hub/migrations/0009_agency_usa_contact_id.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('foia_hub', '0008_auto_20141010_1652'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='agency',
+            name='usa_contact_id',
+            field=models.IntegerField(null=True, help_text='usa.gov contacts api id.'),
+            preserve_default=True,
+        ),
+    ]

--- a/foia_hub/models.py
+++ b/foia_hub/models.py
@@ -83,6 +83,10 @@ class Agency(Contactable):
     common_requests = JSONField(default=empty_list)
     no_records_about = JSONField(default=empty_list)
 
+    usa_contact_id = models.IntegerField(null=True,
+        help_text='usa.gov contacts api id.'
+        )
+
     parent = models.ForeignKey(
         'self',
         null=True,


### PR DESCRIPTION
Adding field to store usa.gov agency id to make updates easier and to insure accuracy in the future when updating. 
