### PR TITLE
Addresses broken links in /learn

### DIFF
--- a/foia_hub/templates/learn.html
+++ b/foia_hub/templates/learn.html
@@ -12,7 +12,7 @@
 
     <p><strong>Why would I make a FOIA request?</strong></p>
 
-    <p>While the Federal Government makes a lot of information <a href="data.gov">available</a> in <a href="search.usa.gov">many</a> <a href="http://foia.state.gov/Search/Search.aspx">places</a>, you may still seek information that has not already been publicly released. FOIA makes it possible to access records that are not yet publicly available.</p>
+    <p>While the Federal Government makes a lot of information <a href="https://www.data.gov">available</a> in many <a href="http://foia.state.gov/Search/Search.aspx">places</a>, you may still seek information that has not already been publicly released. FOIA makes it possible to access records that are not yet publicly available.</p>
 
     <p><strong>What can I ask for?</strong></p>
 


### PR DESCRIPTION
Resolves #150. Thanks for catching, @khandelwal. I removed the link to `search.usa.gov` because that now redirects to `www.usa.gov`, and it's not clear to me where it's meant to go now.
