### PR TITLE
sort offices on landing page alphabetically

### DIFF
--- a/foia_hub/api.py
+++ b/foia_hub/api.py
@@ -32,19 +32,7 @@ def full_office_preparer():
         'id': 'id',
         'name': 'name',
         'slug': 'slug',
-
-        #'service_center': 'service_center',
         'fax': 'fax',
-
-        #'request_form': 'request_form',
-        #'website': 'website',
-        #'emails': 'emails',
-
-        #'contact': 'contact',
-        #'contact_phone': 'contact_phone',
-        #'public_liaison': 'public_liaison',
-
-        #'notes': 'notes',
     })
     return preparer
 
@@ -90,7 +78,7 @@ class AgencyOfficeResource(DjangoResource):
 
     def prepare_agency_contact(self, agency):
         offices = []
-        for o in agency.office_set.all():
+        for o in agency.office_set.order_by('name').all():
             offices.append(self.full_office_preparer.prepare(o))
 
         data = {


### PR DESCRIPTION
Sorts offices alphabetically. Fixes #132.

![sorted](https://cloud.githubusercontent.com/assets/4592/4707850/83c5952e-5891-11e4-8f1a-e5c4f51e09e8.png)
