### PR TITLE
Tightens up Google Analytics snippet

### DIFF
--- a/foia_hub/templates/base.html
+++ b/foia_hub/templates/base.html
@@ -29,9 +29,10 @@
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', '{{ ANALYTICS_ID }}', 'auto');
+  ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 </script>
 </body>


### PR DESCRIPTION
Forces the initial analytics include to be https (frustrating and useless, since that include then loads another include, which doesn't force https, but a symbolic choice anyway), and uses [Google's anonymize IP flag](https://support.google.com/analytics/answer/2763052?hl=en).

Fixes #124.
