### PR TITLE
Offer feature switch to turn off link to our webform

### DIFF
--- a/foia_hub/settings/dev.py
+++ b/foia_hub/settings/dev.py
@@ -3,6 +3,8 @@ from .base import *
 DEBUG = True
 TEMPLATE_DEBUG = True
 
+SHOW_WEBFORM = False
+
 INSTALLED_APPS = (
     'debug_toolbar',
 ) + INSTALLED_APPS

--- a/foia_hub/settings/production.py
+++ b/foia_hub/settings/production.py
@@ -3,6 +3,8 @@ from .base import *
 DEBUG = False
 TEMPLATE_DEBUG = False
 
+SHOW_WEBFORM = False
+
 ALLOWED_HOSTS = ['foia.18f.us']
 
 # if testing out production settings in development:

--- a/foia_hub/settings/test.py
+++ b/foia_hub/settings/test.py
@@ -2,6 +2,8 @@ from .base import *
 
 SECRET_KEY = '#-nl=1b8yr*zr&6dmnv8rj5(f8w7^lv6lyd)7eyjg_xqk$zhe$'
 
+SHOW_WEBFORM = True
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3'

--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -128,25 +128,28 @@
   </header>
 
   <div class="left">
-    <div class="webform contact_type">
-      <div class="icon">
-        <span class="fa fa-desktop"></span>
+
+    {% if profile.request_form_url or show_webform %}
+      <div class="webform contact_type">
+        <div class="icon">
+          <span class="fa fa-desktop"></span>
+        </div>
+        <div class="subdetails">
+          <h3>Request online</h3>
+          <ul>
+            <li><a
+              {% if profile.request_form_url %}
+                href="{{ profile.request_form_url }}"
+              {% else %}
+                href="/request/{{ slug }}"
+              {% endif %}
+              >
+                Submit a request via web
+            </a></li>
+          </ul>
+        </div>
       </div>
-      <div class="subdetails">
-        <h3>Request online</h3>
-        <ul>
-          <li><a
-            {% if profile.request_form_url %}
-              href="{{ profile.request_form_url }}"
-            {% else %}
-              href="/request/{{ slug }}"
-            {% endif %}
-            >
-              Submit a request via web
-          </a></li>
-        </ul>
-      </div>
-    </div>
+    {% endif %}
 
     <div class="address contact_type">
       <div class="icon">

--- a/foia_hub/views.py
+++ b/foia_hub/views.py
@@ -28,7 +28,7 @@ def contact_landing(request, slug):
         template = env.get_template('contacts/parent_profile.html')
     else:
         template = env.get_template('contacts/profile.html')
-    return HttpResponse(template.render(profile=data, slug=slug))
+    return HttpResponse(template.render(profile=data, slug=slug, show_webform=settings.SHOW_WEBFORM))
 
 
 ###


### PR DESCRIPTION
This adds a `SHOW_WEBFORM` setting. If set to True, the app will display the behavior it has been, which is to link to our basic webform whenever the agency/office does not provide one. If set to False, the app will demonstrate new behavior, which is to hide the webform section entirely if the agency/office does not provide one.

This allows us to pass the app around publicly a little more easily, since the webform still has some more work to be done before it's fully operational.

Fixes #250.
