### PR TITLE
Document removal of unnecessary 2>&1

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -53,7 +53,7 @@ You may wish to use [ngrok](https://ngrok.com/) or [localtunnel](https://localtu
 On the staging server, this hookshot daemon is run:
 
 ```
-forever start -l $HOME/hub/shared/log/hookshot.log -a deploy/hookshot.js -p 3000 -b master -c "bash $HOME/bin/deploy-site.sh >> $HOME/hub/shared/log/hookshot.log 2>&1"
+forever start -l $HOME/hub/shared/log/hookshot.log -a deploy/hookshot.js -p 3000 -b master -c "bash $HOME/bin/deploy-site.sh >> $HOME/hub/shared/log/hookshot.log"
 ```
 
 It should be run from the project root (the `current` dir/symlink). Both the hook and the output log to the same file, and when it's hit it will execute a small bash script:


### PR DESCRIPTION
I'm not sure why this was in here. I don't think it was the culprit in breaking the webhook -- but I don't have a clear idea of why the webhook wasn't using bash properly in the first place.

The webhook was broken because it couldn't run `workon` correctly (part of `virtualenvwrapper`, a bash alias and not an actual binary command) because the script it runs was being run under `sh` and not `bash`. I've restarted the webhook, and things seem to be all well now.
