### PR TITLE
Early return meant multiple reading room links were not added

### DIFF
--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -119,6 +119,7 @@ def add_request_time_statistics(data, agency, office=None):
             stat.median = median
             stat.save()
 
+
 def add_reading_rooms(contactable, reading_rooms):
     for link_text, url in reading_rooms:
         existing_room = ReadingRoomUrls.objects.filter(
@@ -130,7 +131,8 @@ def add_reading_rooms(contactable, reading_rooms):
             r = ReadingRoomUrls(link_text=link_text, url=url)
             r.save()
             contactable.reading_room_urls.add(r)
-        return contactable
+    return contactable
+
 
 def build_abbreviation(agency_name):
     """ Given an agency name, guess at an abbrevation. """
@@ -145,9 +147,7 @@ def process_yamls(folder):
 
     # only load yaml files
     for item in iglob(folder + "/*.yaml"):
-
         data_file = os.path.join(folder, item)
-
         data = yaml.load(open(data_file))
 
         # Agencies
@@ -162,14 +162,12 @@ def process_yamls(folder):
         a.common_requests = data.get('common_requests', [])
         a.no_records_about = data.get('no_records_about', [])
 
-
         #   Only has a single, main branch/office
         if len(data['departments']) == 1:
             dept_rec = data['departments'][0]
             contactable_fields(a, dept_rec)
 
         a.save()
-
         add_request_time_statistics(data, a)
 
         # Offices
@@ -194,7 +192,6 @@ def process_yamls(folder):
                         'no_records_about', [])
                     contactable_fields(sub_agency, dept_rec)
                     sub_agency.save()
-
                     add_request_time_statistics(dept_rec, sub_agency)
                 else:
                     # Just an office

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -9,16 +9,24 @@ class LoadingTest(TestCase):
 
     def test_add_reading_rooms(self):
         reading_room_links = [[
-            'Electronic Reading Room', 'http://agency.gov/err/']]
+            'Electronic Reading Room', 'http://agency.gov/err/'],
+            ['Pre-2000 Reading Room', 'http://agency.gov/pre-2000/rooms']]
         agency = Agency.objects.get(slug='department-of-homeland-security')
         agency = add_reading_rooms(agency, reading_room_links)
         agency.save()
 
         # Retrieve saved
         dhs = Agency.objects.get(slug='department-of-homeland-security')
+        self.assertEqual(2, len(dhs.reading_room_urls.all()))
         self.assertEqual(
             'Electronic Reading Room',
             dhs.reading_room_urls.all()[0].link_text)
         self.assertEqual(
             'http://agency.gov/err/',
             dhs.reading_room_urls.all()[0].url)
+        self.assertEqual(
+            'Pre-2000 Reading Room',
+            dhs.reading_room_urls.all()[1].link_text)
+        self.assertEqual(
+            'http://agency.gov/pre-2000/rooms',
+            dhs.reading_room_urls.all()[1].url)


### PR DESCRIPTION
I had a bug where the function that adds reading room links to the database only added one. Now it adds multiple links as it should have. 

The relevant test has also been updated to reflect multiple reading room links. 
