### PR TITLE
Requests API turns off when form isn't shown

### DIFF
--- a/foia_hub/urls.py
+++ b/foia_hub/urls.py
@@ -25,8 +25,12 @@ urlpatterns += patterns(
     '',
     url(r'^api/agency/', include(AgencyResource.urls())),
     url(r'^api/office/', include(OfficeResource.urls())),
-    url(r'^api/request/', include(FOIARequestResource.urls())),
 )
+
+if settings.SHOW_WEBFORM:
+    urlpatterns += patterns(
+        '',
+        url(r'^api/request/', include(FOIARequestResource.urls())))
 
 # Admin
 admin.autodiscover()


### PR DESCRIPTION
We use SHOW_WEBFORM to turn the request webform off. We now turn off the requests API if SHOW_WEBFORM=False. 

Fixes: https://github.com/18F/foia-hub/issues/280
