### PR TITLE
Fix title tag too

### DIFF
--- a/foia_hub/templates/base.html
+++ b/foia_hub/templates/base.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>{% block title %}
-    alpha.FOIA.gov > Freedom of Information Act
+    FOIA HUB > Freedom of Information Act
   {% endblock %}</title>
 
   {% include "includes/head.html" %}


### PR DESCRIPTION
The `<title>` tag still said `alpha.FOIA.gov`. Now it says `FOIA Hub`.
