### PR TITLE
Always generate datestamp for deploys from UTC

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -25,10 +25,14 @@ repo = "git@github.com:18f/foia-hub.git"
 #   shared/
 #      log/
 #      settings.py
+
+# always UTC datestamp, so it doesn't matter what computer does the deploy
+datestamp = time.strftime("%Y%m%d%H%M%S", time.gmtime(time.mktime(time.localtime())))
+
 home = "/home/foia/hub"
 shared_path = "%s/shared" % home
 versions_path = "%s/versions" % home
-version_path = "%s/%s" % (versions_path, time.strftime("%Y%m%d%H%M%S"))
+version_path = "%s/%s" % (versions_path, datestamp)
 current_path = "%s/current" % home
 logs = "%s/log" % shared_path
 


### PR DESCRIPTION
My local computer is on EST, and our server is on UTC. This caused a fun bug, where I had done 5 server-generated deploys (using the webhook) that used UTC time, and then ran a manual one from my computer (5 hours behind).

This meant that the old deploy cleanup task, which keeps the 5 most recent deploys, was actually deleting the newest deploy, because its EST timestamp was _older_ than the previous UT timestamp timezones I'd deployed. This caused the server to go down, because it shifted the `current/` symlink to a directory that had just been deleted during trhe cleanup.

This PR ensures that the timezone used to generate deployed datestamps will always be consistent.
