### PR TITLE
change median to 1, but keep the flag

### DIFF
--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -122,7 +122,7 @@ def add_request_time_statistics(data, agency, office=None):
                 stat_type=arg[0])
 
             if median == 'less than 1':
-                stat.median = 0
+                stat.median = 1
                 stat.less_than_one = True
             else:
                 stat.median = median

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -48,7 +48,7 @@ class LoadingTest(TestCase):
         # Verify latest data is returned when it exists
         retrieved = agency.stats_set.filter(
             stat_type='S').order_by('-year').first()
-        self.assertEqual(retrieved.median, 0)
+        self.assertEqual(retrieved.median, 1)
 
         # Verify that `less than one` records are flagged
         retrieved = agency.stats_set.filter(


### PR DESCRIPTION
Based on #306 
Jake mentioned that agencies **should** not have `<1` as the value for medians or means. 
I changed the default value for medians with a value of `<1` from 0 to 1 to reflect his suggestion, but kept the flag.
