### PR TITLE
Start showing the FOIA libraries again

### DIFF
--- a/foia_hub/templates/contacts/contact.html
+++ b/foia_hub/templates/contacts/contact.html
@@ -1,16 +1,16 @@
 
-{% if profile.reading_rooms %}
+{% if profile.foia_libraries %}
     <div class="reading_room resource_type">
         <div class="icon">
             <span class="fa fa-bookmark"></span>
         </div>
         <div class="subdetails">
-            {% if profile.reading_rooms|length > 1 %}
+            {% if profile.foia_libraries|length > 1 %}
             <h3>FOIA Libraries</h3>
             {% else %}
             <h3>FOIA Library</h3>
             {% endif %}
-            {% for r in profile.reading_rooms%}
+            {% for r in profile.foia_libraries %}
                 <ul>
                     <li> <a href="{{r.url}}">{{r.link_text}}</a></li>
                 </ul>

--- a/foia_hub/views.py
+++ b/foia_hub/views.py
@@ -14,9 +14,11 @@ env.globals['ANALYTICS_ID'] = settings.ANALYTICS_ID
 # Finding agencies and their contact information.
 ###
 
+
 def home(request):
     """App home page."""
     return HttpResponse(env.get_template('index.html').render())
+
 
 def agencies(request):
     """Full agency listing."""
@@ -26,7 +28,9 @@ def agencies(request):
     if len(agencies) == 1:
         return redirect('contact_landing', slug=agencies[0].slug)
     else:
-        return HttpResponse(env.get_template('contacts/index.html').render(agencies=agencies, query=query))
+        return HttpResponse(env.get_template('contacts/index.html').render(
+            agencies=agencies, query=query))
+
 
 def contact_landing(request, slug):
     """Principal landing page for agencies and offices."""


### PR DESCRIPTION
We changed the API to represent reading_rooms as foia_libraries but did not update our corresponding Django templates. Reading rooms were not showing up on the contact landing pages. 

This fixes the templates, and adds tests to ensure that there's a test failure if the foia libraries aren't rendered. 
Also, there are some PEP8 related changes. 

![selfie-0](http://i.imgur.com/ylXQiZb.png)
