### PR TITLE
added working days to median stats

### DIFF
--- a/foia_hub/models.py
+++ b/foia_hub/models.py
@@ -164,7 +164,7 @@ class Office(Contactable):
 class Stats(models.Model):
     """
     The Stats model stores request processing time data scraped from foia.gov.
-    Currently this model only stores the median number of days
+    Currently this model only stores the median number of working days
     simple and complex requests take to complete.
 
     Simple Request – A FOIA request that an agency anticipates will

--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -58,14 +58,14 @@
             {% if profile.simple_processing_time %}
               <li>
                 Simple requests:
-                {{ profile.simple_processing_time|int }} days
+                {{ profile.simple_processing_time|int }} working days
               </li>
             {% endif %}
 
             {% if profile.complex_processing_time %}
               <li>
                 Complex requests:
-                {{ profile.complex_processing_time|int }} days
+                {{ profile.complex_processing_time|int }} working days
               </li>
             {% endif %}
           </ul>


### PR DESCRIPTION
Small PR takes care of 18F/foia-hub/issues/364

Unfortunately, for Complex requests "days" starts a new line regardless of the size of the frame. 
