### PR TITLE
Fixed number formatting and added tests

### DIFF
--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -35,7 +35,7 @@ TTY_RE = re.compile('\(?\d{3}\)? \d{3}-\d{4} \(TTY\)')
 ADDY_RE = re.compile('(?P<city>.*), (?P<state>[A-Z]{2}) (?P<zip>[0-9-]+)')
 
 
-def clean_phone(number_str):
+def clean_phone_number(number_str):
     """Cut down the phone number string as much as possible. If multiple
     numbers are present, take the first only"""
 
@@ -58,11 +58,11 @@ def contactable_fields(agency, office_dict):
     """Add the Contactable and USAddress fields to the agency based on values
     in the office dictionary. This will be called for both parent and child
     agencies/offices (as written in our current data set)"""
-    agency.phone = clean_phone(office_dict.get('phone'))
+    agency.phone = clean_phone_number(office_dict.get('phone'))
 
     # a.toll_free_phone - not an explicit field in our data set
     agency.emails = office_dict.get('emails', [])
-    agency.fax = clean_phone(office_dict.get('fax'))
+    agency.fax = clean_phone_number(office_dict.get('fax'))
     agency.office_url = office_dict.get('website')
 
     agency.request_form_url = office_dict.get('request_form')
@@ -88,7 +88,7 @@ def contactable_fields(agency, office_dict):
         match = TTY_RE.search(phone)
         if match:
             phone = phone[:match.start()].strip()
-        agency.public_liaison_phone = clean_phone(phone)
+        agency.public_liaison_phone = clean_phone_number(phone)
     else:
         name = public_liaison
     agency.public_liaison_name = name or None

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -38,9 +38,16 @@ ADDY_RE = re.compile('(?P<city>.*), (?P<state>[A-Z]{2}) (?P<zip>[0-9-]+)')
 def clean_phone(number_str):
     """Cut down the phone number string as much as possible. If multiple
     numbers are present, take the first only"""
+
     number_str = number_str or ''
-    number_str = number_str.replace('(', '').replace(')', '')
-    number_str = number_str.replace('ext. ', 'x').replace('ext ', 'x')
+
+    if '+' in number_str:
+        return number_str
+
+    number_str = number_str.replace('(', '')
+    number_str = re.sub('[)][- ]?', '-', number_str)
+    number_str = number_str.replace(' ', '')
+    number_str = re.sub('[, ]*ext[. ]*', ' x', number_str)
     number_str = number_str.split(',')[0].strip()
 
     if number_str:
@@ -52,6 +59,7 @@ def contactable_fields(agency, office_dict):
     in the office dictionary. This will be called for both parent and child
     agencies/offices (as written in our current data set)"""
     agency.phone = clean_phone(office_dict.get('phone'))
+
     # a.toll_free_phone - not an explicit field in our data set
     agency.emails = office_dict.get('emails', [])
     agency.fax = clean_phone(office_dict.get('fax'))

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -2,7 +2,8 @@ from django.test import TestCase
 
 from foia_hub.models import Agency, Office
 from foia_hub.scripts.load_agency_contacts import \
-    add_reading_rooms, add_request_time_statistics, load_data, clean_phone
+    add_reading_rooms, add_request_time_statistics, load_data, \
+    clean_phone_number
 
 
 example_office1 = {
@@ -166,31 +167,31 @@ class LoadingTest(TestCase):
         """ Verify that phone numbers are correctly formatted """
 
         test_number = '555-555-5555'
-        self.assertEqual('555-555-5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555', clean_phone_number(test_number))
 
         test_number = '(555) 555-5555'
-        self.assertEqual('555-555-5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555', clean_phone_number(test_number))
 
         test_number = '(555)-555-5555'
-        self.assertEqual('555-555-5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555', clean_phone_number(test_number))
 
         test_number = '(555)555-5555'
-        self.assertEqual('555-555-5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555', clean_phone_number(test_number))
 
         test_number = '(555) 555-5555 ext. 5555'
-        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555 x5555', clean_phone_number(test_number))
 
         test_number = '(555) 555-5555, ext 5555'
-        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555 x5555', clean_phone_number(test_number))
 
         test_number = '(555) 555-5555, ext. 5555'
-        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555 x5555', clean_phone_number(test_number))
 
         test_number = '555-555-5555, (555) 555-5555, ext. 5555'
-        self.assertEqual('555-555-5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555', clean_phone_number(test_number))
 
         test_number = '(555) 555-5555, ext. 5555,  555-555-5555'
-        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+        self.assertEqual('555-555-5555 x5555', clean_phone_number(test_number))
 
         test_number = '+011 555-555-5555'
-        self.assertEqual('+011 555-555-5555', clean_phone(test_number))
+        self.assertEqual('+011 555-555-5555', clean_phone_number(test_number))

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from foia_hub.models import Agency, Office
 from foia_hub.scripts.load_agency_contacts import \
-    add_reading_rooms, add_request_time_statistics, load_data
+    add_reading_rooms, add_request_time_statistics, load_data, clean_phone
 
 
 example_office1 = {
@@ -162,4 +162,35 @@ class LoadingTest(TestCase):
             'environmental-protection-agency-' +
             '-region-9-states-az-ca-hi-nv-as-gu', o.slug)
 
-    # TODO add tests for contactable_fields
+    def test_clean_phone(self):
+        """ Verify that phone numbers are correctly formatted """
+
+        test_number = '555-555-5555'
+        self.assertEqual('555-555-5555', clean_phone(test_number))
+
+        test_number = '(555) 555-5555'
+        self.assertEqual('555-555-5555', clean_phone(test_number))
+
+        test_number = '(555)-555-5555'
+        self.assertEqual('555-555-5555', clean_phone(test_number))
+
+        test_number = '(555)555-5555'
+        self.assertEqual('555-555-5555', clean_phone(test_number))
+
+        test_number = '(555) 555-5555 ext. 5555'
+        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+
+        test_number = '(555) 555-5555, ext 5555'
+        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+
+        test_number = '(555) 555-5555, ext. 5555'
+        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+
+        test_number = '555-555-5555, (555) 555-5555, ext. 5555'
+        self.assertEqual('555-555-5555', clean_phone(test_number))
+
+        test_number = '(555) 555-5555, ext. 5555,  555-555-5555'
+        self.assertEqual('555-555-5555 x5555', clean_phone(test_number))
+
+        test_number = '+011 555-555-5555'
+        self.assertEqual('+011 555-555-5555', clean_phone(test_number))


### PR DESCRIPTION
Updates: 
1. Standardizes number formatting in loading function to (\d{3}-\d{3}-\d{4}) and (\d{3}-\d{3}-\d{4} x\d*) for numbers with extensions.
2. Ensures that extension stays in numbers such as (555) 555-5555, ext. 5555 
3. Four numbers had international codes, I chose to leave those numbers as is. We can correct their formatting in the manual data.

Should take care of issue 18F/foia-hub/issues/374