### PR TITLE
Simpler search

### DIFF
--- a/foia_hub/static/js/requests/index.js
+++ b/foia_hub/static/js/requests/index.js
@@ -51,8 +51,9 @@ $(document).ready(function() {
     currentText = $(ev.target).val();
     if (currentText.length > longestText.length) {
       longestText = currentText;
+    }
     //  blanked out the text after initially typing something
-    } else if (currentText.length === 0 && longestText.length > 0) {
+    else if (currentText.length === 0 && longestText.length > 0) {
       ga('send', 'event', 'contacts', 'did-not-want', longestText);
       longestText = '';
     }
@@ -63,7 +64,8 @@ $(document).ready(function() {
   onSelection = function(ev, suggestion) {
     if (suggestion.isFooter) {
       $(ev.target).val(suggestion.query).closest('form').submit();
-    } else {
+    }
+    else {
       var callback = function() {
         window.location = '/contacts/' + suggestion.slug + '/';
       };

--- a/foia_hub/static/js/requests/index.js
+++ b/foia_hub/static/js/requests/index.js
@@ -12,14 +12,12 @@ $(document).ready(function() {
     queryTokenizer: Bloodhound.tokenizers.whitespace,
     // prefetch: '/api/agency/',
     limit: 500, // infinity
-    prefetch: {url: "/api/agency/", filter: function(response) {return response.objects; }},
+    prefetch: {url: '/api/agency/', filter: function(response) {
+      return response.objects; }},
     datumTokenizer: function(d) {
       return []
         .concat(Bloodhound.tokenizers.whitespace(d.name))
-        .concat(Bloodhound.tokenizers.whitespace(d.description))
-        .concat(Bloodhound.tokenizers.whitespace(d.abbreviation))
-        .concat(Bloodhound.tokenizers.whitespace(
-          d.keywords ? d.keywords.join(' ') : []));
+        .concat(Bloodhound.tokenizers.whitespace(d.abbreviation));
     }
   });
   // always clear local storage for new requests, at least in dev
@@ -32,10 +30,7 @@ $(document).ready(function() {
     displayKey: 'value',
     source: agencyDatasource.ttAdapter(),
     templates: {
-      suggestion: Handlebars.compile(
-        ['<h5 class="agency-name">{{name}}</h5>',
-         '<p class="agency-description">{{description}}</p>'].join('')
-      )
+      suggestion: Handlebars.compile('<h5 class="agency-name">{{name}}</h5>')
     }
   };
 


### PR DESCRIPTION
* For autocomplete, only search agency names and abbreviations
* Don't display descriptions in auto complete box
* Add a final option in all search results for searching over descriptions & keywords

![screen shot 2015-01-16 at 11 32 31 am](https://cloud.githubusercontent.com/assets/326918/5780873/9f17d928-9d73-11e4-82a8-ed52adc7b939.png)

Clicking/down-arrowing to the final link redirects to `/agencies/?query=ener`

This'd be better with JS tests, but I don't think this project's set up for that?