### PR TITLE
Redesign: Sitewide elements, typography, home page implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ debug.log
 *.pyo
 *.DS_Store
 *.swp
+*.codekit
 
 # SCSS/SASS
 .sass-cache

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -397,6 +397,7 @@ h4,
 h5,
 h6 {
   font-family: "proxima-nova", "open sans", arial, sans-serif;
+  font-weight: 600;
   line-height: 1.25;
   margin: 0;
   text-rendering: optimizeLegibility;
@@ -407,7 +408,8 @@ h1 {
 
 h2 {
   font-size: 2em;
-  border-bottom: 0.2em solid #00BFE7; }
+  border-bottom: 0.15em solid #00BFE7;
+  padding-bottom: 0.2em; }
 
 h3 {
   font-size: 1.75em; }
@@ -665,13 +667,11 @@ body > header {
     display: inline-block;
     padding: 0 10px 0 10px; }
   body > header nav ul a {
-    color: #333;
+    color: #777777;
     padding-bottom: 12px; }
   body > header nav ul a:hover, body > header nav ul a.active {
-    border-bottom: 0.3em solid #00BFE7; }
-  body > header nav ul a:hover {
-    background: none;
-    color: #777; }
+    border-bottom: 0.3em solid #00BFE7;
+    color: #323A45; }
   body > header nav ul a:focus {
     background: #fff;
     color: #1188ff; }
@@ -690,18 +690,23 @@ body > header {
  */
 div#usa {
   background-color: #323A45;
-  color: #EAEDF1; }
+  color: #EAEDF1;
+  padding: 0.25em 0; }
   div#usa .usa--content {
-    padding-top: 0.75em;
-    margin-bottom: 0.8em; }
+    font-size: 0.8em; }
   div#usa .official {
     float: left; }
   div#usa .alpha {
     float: right; }
-  @media screen and (max-width: 48em) {
-    div#usa .official, div#usa .alpha {
-      float: none;
-      text-align: center; } }
+  div#usa .official, div#usa .alpha {
+    display: inline-block; }
+    div#usa .official a, div#usa .alpha a {
+      color: #00BFE7; }
+    @media screen and (max-width: 48em) {
+      div#usa .official, div#usa .alpha {
+        float: none;
+        display: block;
+        text-align: center; } }
 
 #main {
   /* /about and /learn */ }
@@ -709,7 +714,8 @@ div#usa {
     padding-top: 20px; }
   #main .search {
     background: #323A45;
-    color: #EAEDF1; }
+    color: #EAEDF1;
+    padding: 3.4em 0; }
   #main .search--content {
     margin-left: 16.8421052632%;
     float: left;
@@ -746,10 +752,6 @@ div#usa {
         #main .search--content:last-child {
           margin-right: 0; } }
     #main .search--content h2 {
-      text-align: center;
-      font-weight: normal;
-      margin: 0;
-      padding: 0;
       border-bottom: none; }
     #main .search--content a {
       color: #00BFE7;
@@ -875,10 +877,13 @@ div#usa {
         .hero > .container > .hero--content:last-child {
           margin-right: 0; } }
     .hero > .container > .hero--content p {
-      /* VZ: This should be moved to a variable. Prob powered by Bitters. */
-      margin-top: 30px;
       font-size: 2em;
-      line-height: 40px; }
+      line-height: 1.25;
+      font-weight: 600;
+      margin: 1em 0; }
+    .hero > .container > .hero--content a.more {
+      font-size: 1em;
+      font-weight: 600; }
 
 @media screen and (max-width: 30em) {
   .hero {
@@ -1066,10 +1071,6 @@ div#usa {
   #main.landing .resource_type .subdetails, #main.landing .contact_type .subdetails {
     display: inline-block;
     overflow: hidden; }
-  #main.landing .resource_type h3, #main.landing .contact_type h3 {
-    padding: 0;
-    margin: 0;
-    font-weight: bold; }
   #main.landing .resource_type ul, #main.landing .resource_type li, #main.landing .contact_type ul, #main.landing .contact_type li {
     list-style-type: none;
     list-style-position: outside;
@@ -1087,12 +1088,9 @@ div#usa {
 #main.landing .resource_type h3 {
   font-size: 1em; }
 #main.landing .contact_type h3 {
-  font-size: 1.6em;
-  font-weight: normal;
   margin-bottom: 5px; }
 #main.landing .inaccurate p {
-  font-size: 1em;
-  font-weight: bold; }
+  font-size: 1em; }
 
 form.request input.upto[type=text] {
   width: 80px;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -627,14 +627,6 @@ body > header {
     body > header #logo em {
       color: #cc2211;
       font-style: normal; }
-  @media screen and (max-width: 30em) {
-    body > header #topnav nav ul {
-      float: left;
-      display: block;
-      margin-right: 6.6666666667%;
-      width: 73.3333333333%; }
-      body > header #topnav nav ul:last-child {
-        margin-right: 0; } }
   body > header #topnav nav ul li {
     display: inline-block;
     padding: 0 10px; }
@@ -671,7 +663,8 @@ div#usa {
   color: #EAEDF1;
   padding: 0.25em 0; }
   div#usa .usa--content {
-    font-size: 0.8em; }
+    font-size: 0.8em;
+    font-weight: 800; }
   div#usa .official {
     float: left; }
   div#usa .alpha {
@@ -693,22 +686,17 @@ div#usa {
   color: #EAEDF1;
   padding: 3.4em 0; }
 #main .search--content {
-  margin-left: 106.6666666667%;
+  margin-left: 16.8421052632%;
   float: left;
   display: block;
   margin-right: 1.0526315789%;
-  width: 66.3157894737%; }
+  width: 66.3157894737%;
+  /*  @include media($large) {
+      @include shift(2);
+      @include span-columns(20)
+    }*/ }
   #main .search--content:last-child {
     margin-right: 0; }
-  @media screen and (max-width: 61.25em) {
-    #main .search--content {
-      margin-left: 8.4210526316%;
-      float: left;
-      display: block;
-      margin-right: 1.0526315789%;
-      width: 83.1578947368%; }
-      #main .search--content:last-child {
-        margin-right: 0; } }
   @media screen and (max-width: 48em) {
     #main .search--content {
       margin-left: 4.2105263158%;
@@ -823,18 +811,13 @@ div#usa {
     float: left;
     display: block;
     margin-right: 1.0526315789%;
-    width: 66.3157894737%; }
+    width: 66.3157894737%;
+    /*  @include media($large) {
+        @include shift(2);
+        @include span-columns(20)
+      }*/ }
     .hero > .container > .hero--content:last-child {
       margin-right: 0; }
-    @media screen and (max-width: 61.25em) {
-      .hero > .container > .hero--content {
-        margin-left: 8.4210526316%;
-        float: left;
-        display: block;
-        margin-right: 1.0526315789%;
-        width: 83.1578947368%; }
-        .hero > .container > .hero--content:last-child {
-          margin-right: 0; } }
     @media screen and (max-width: 48em) {
       .hero > .container > .hero--content {
         margin-left: 4.2105263158%;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -646,28 +646,27 @@ body {
   padding-bottom: 20px; }
 
 body > header {
-  border-bottom: 1px solid #dedede;
-  /* Wordmark */ }
+  border-bottom: 1px solid #dedede; }
   body > header a:hover {
     text-decoration: none; }
-  body > header h1 {
+  body > header #topnav {
+    margin: 1em 0 0.8em; }
+  body > header #logo {
     float: left;
-    font-weight: normal;
-    font-size: 2em;
     color: #0096B5; }
-    body > header h1 a {
+    body > header #logo a {
       color: #0096B5; }
-    body > header h1 strong {
+    body > header #logo strong {
       font-weight: 800; }
-    body > header h1 em {
+    body > header #logo em {
       color: #cc2211;
       font-style: normal; }
   body > header nav ul li {
     display: inline-block;
-    padding: 9px 10px 0 10px; }
+    padding: 0 10px 0 10px; }
   body > header nav ul a {
     color: #333;
-    padding: 0 0px 6px 0; }
+    padding-bottom: 12px; }
   body > header nav ul a:hover, body > header nav ul a.active {
     border-bottom: 0.3em solid #00BFE7; }
   body > header nav ul a:hover {
@@ -752,13 +751,11 @@ div#usa {
       margin: 0;
       padding: 0;
       border-bottom: none; }
-    #main .search--content p {
-      margin-top: 30px; }
+    #main .search--content a {
+      color: #00BFE7;
+      font-weight: 800; }
     #main .search--content .search-box {
       margin-top: 30px; }
-    #main .search--content p.browse {
-      margin-top: 15px;
-      text-align: center; }
   #main footer div.left {
     float: left;
     display: block;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -364,7 +364,7 @@ th {
 button,
 input[type="submit"] {
   -webkit-font-smoothing: antialiased;
-  background-color: #0096B5;
+  background-color: #0067BA;
   border-radius: 3px;
   color: white;
   display: inline-block;
@@ -375,7 +375,7 @@ input[type="submit"] {
   text-decoration: none; }
   button:hover,
   input[type="submit"]:hover {
-    background-color: #005769;
+    background-color: #003d6e;
     color: white; }
   button:disabled,
   input[type="submit"]:disabled {
@@ -386,7 +386,7 @@ body {
   -webkit-font-smoothing: antialiased;
   background-color: white;
   color: #323A45;
-  font-family: "proxima-nova", "open sans", arial, sans-serif;
+  font-family: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
   font-size: 1em;
   line-height: 1.5; }
 
@@ -396,20 +396,26 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "proxima-nova", "open sans", arial, sans-serif;
+  font-family: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
   font-weight: 600;
   line-height: 1.25;
   margin: 0;
   text-rendering: optimizeLegibility;
   display: inline-block; }
 
+.hero--content h1, .hero--content h2, .hero--content h3, .hero--content h4, .hero--content h5, .hero--content h6 {
+  padding-bottom: 0.8em; }
+
 h1 {
   font-size: 2.25em; }
 
 h2 {
-  font-size: 2em;
+  font-size: 2em; }
+
+h1 em, h2 em, h3 em, h4 em, h5 em, h6 em {
   border-bottom: 0.15em solid #00BFE7;
-  padding-bottom: 0.2em; }
+  line-height: 1.5625;
+  font-style: normal; }
 
 h3 {
   font-size: 1.75em; }
@@ -430,12 +436,12 @@ a {
   -webkit-transition: color 0.1s linear;
   -moz-transition: color 0.1s linear;
   transition: color 0.1s linear;
-  color: #0096B5;
+  color: #0067BA;
   text-decoration: none; }
   a:hover {
-    color: #005769; }
+    color: #003d6e; }
   a:active, a:focus {
-    color: #005769;
+    color: #003d6e;
     outline: none; }
 
 hr {
@@ -472,7 +478,7 @@ input,
 label,
 select {
   display: block;
-  font-family: "proxima-nova", "open sans", arial, sans-serif;
+  font-family: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
   font-size: 1em; }
 
 label {
@@ -496,7 +502,7 @@ select[multiple=multiple] {
   border-radius: 3px;
   border: 1px solid #323A45;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
-  font-family: "proxima-nova", "open sans", arial, sans-serif;
+  font-family: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
   font-size: 1em;
   margin-bottom: 0.75em;
   padding: 0.5em 0.5em;
@@ -508,8 +514,8 @@ select[multiple=multiple] {
   textarea:focus,
   input[type="email"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="text"]:focus, input[type="url"]:focus, input[type="color"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus,
   select[multiple=multiple]:focus {
-    border-color: #0096B5;
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 5px rgba(0, 129, 156, 0.7);
+    border-color: #0067BA;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 5px rgba(0, 89, 161, 0.7);
     outline: none; }
 
 textarea {
@@ -562,6 +568,11 @@ ol {
   margin: 0;
   padding: 0;
   list-style-type: none; }
+  #main.home section.process ol {
+    list-style-type: decimal;
+    margin-bottom: 0.75em;
+    padding-left: 1.5em; }
+
 dl {
   margin-bottom: 0.75em; }
   dl dt {
@@ -597,53 +608,6 @@ html {
   -moz-box-sizing: inherit;
   box-sizing: inherit; }
 
-body:before {
-  content: '';
-  display: inline-block;
-  background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-  background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-  background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-  background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-  background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-  height: 100%;
-  left: 0;
-  margin: 0 auto;
-  max-width: 68em;
-  opacity: 0.4;
-  position: fixed;
-  right: 0;
-  width: 100%;
-  pointer-events: none;
-  z-index: -1; }
-  @media screen and (max-width: 61.25em) {
-    body:before {
-      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
-      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%); } }
-  @media screen and (max-width: 48em) {
-    body:before {
-      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
-      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
-      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
-      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
-      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%); } }
-  @media screen and (max-width: 30em) {
-    body:before {
-      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%); } }
-  @media screen and (max-width: 20em) {
-    body:before {
-      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
-      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%); } }
-
 body {
   padding-bottom: 20px; }
 
@@ -655,24 +619,38 @@ body > header {
     margin: 1em 0 0.8em; }
   body > header #logo {
     float: left;
-    color: #0096B5; }
+    color: #0067BA; }
     body > header #logo a {
-      color: #0096B5; }
+      color: #0067BA; }
     body > header #logo strong {
       font-weight: 800; }
     body > header #logo em {
       color: #cc2211;
       font-style: normal; }
-  body > header nav ul li {
+  @media screen and (max-width: 30em) {
+    body > header #topnav nav ul {
+      float: left;
+      display: block;
+      margin-right: 6.6666666667%;
+      width: 73.3333333333%; }
+      body > header #topnav nav ul:last-child {
+        margin-right: 0; } }
+  body > header #topnav nav ul li {
     display: inline-block;
-    padding: 0 10px 0 10px; }
-  body > header nav ul a {
+    padding: 0 10px; }
+  body > header #topnav nav ul a {
     color: #777777;
     padding-bottom: 12px; }
-  body > header nav ul a:hover, body > header nav ul a.active {
+    @media screen and (max-width: 30em) {
+      body > header #topnav nav ul a {
+        padding-bottom: 0; } }
+  body > header #topnav nav ul a:hover, body > header #topnav nav ul a.active {
     border-bottom: 0.3em solid #00BFE7;
     color: #323A45; }
-  body > header nav ul a:focus {
+    @media screen and (max-width: 30em) {
+      body > header #topnav nav ul a:hover, body > header #topnav nav ul a.active {
+        border-bottom: 1px solid #00BFE7; } }
+  body > header #topnav nav ul a:focus {
     background: #fff;
     color: #1188ff; }
 
@@ -708,56 +686,56 @@ div#usa {
         display: block;
         text-align: center; } }
 
-#main {
-  /* /about and /learn */ }
-  #main .content {
-    padding-top: 20px; }
-  #main .search {
-    background: #323A45;
-    color: #EAEDF1;
-    padding: 3.4em 0; }
-  #main .search--content {
-    margin-left: 16.8421052632%;
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 66.3157894737%; }
-    #main .search--content:last-child {
-      margin-right: 0; }
-    @media screen and (max-width: 61.25em) {
-      #main .search--content {
-        margin-left: 8.4210526316%;
-        float: left;
-        display: block;
-        margin-right: 1.0526315789%;
-        width: 83.1578947368%; }
-        #main .search--content:last-child {
-          margin-right: 0; } }
-    @media screen and (max-width: 48em) {
-      #main .search--content {
-        margin-left: 4.2105263158%;
-        float: left;
-        display: block;
-        margin-right: 2.1276595745%;
-        width: 82.9787234043%; }
-        #main .search--content:last-child {
-          margin-right: 0; } }
-    @media screen and (max-width: 30em) {
-      #main .search--content {
-        margin-left: 0%;
-        float: left;
-        display: block;
-        margin-right: 6.6666666667%;
-        width: 100%; }
-        #main .search--content:last-child {
-          margin-right: 0; } }
-    #main .search--content h2 {
-      border-bottom: none; }
-    #main .search--content a {
-      color: #00BFE7;
-      font-weight: 800; }
-    #main .search--content .search-box {
-      margin-top: 30px; }
+#main .content {
+  padding-top: 20px; }
+#main .search {
+  background: #323A45;
+  color: #EAEDF1;
+  padding: 3.4em 0; }
+#main .search--content {
+  margin-left: 106.6666666667%;
+  float: left;
+  display: block;
+  margin-right: 1.0526315789%;
+  width: 66.3157894737%; }
+  #main .search--content:last-child {
+    margin-right: 0; }
+  @media screen and (max-width: 61.25em) {
+    #main .search--content {
+      margin-left: 8.4210526316%;
+      float: left;
+      display: block;
+      margin-right: 1.0526315789%;
+      width: 83.1578947368%; }
+      #main .search--content:last-child {
+        margin-right: 0; } }
+  @media screen and (max-width: 48em) {
+    #main .search--content {
+      margin-left: 4.2105263158%;
+      float: left;
+      display: block;
+      margin-right: 2.1276595745%;
+      width: 82.9787234043%; }
+      #main .search--content:last-child {
+        margin-right: 0; } }
+  @media screen and (max-width: 30em) {
+    #main .search--content {
+      margin-left: 0%;
+      float: left;
+      display: block;
+      margin-right: 6.6666666667%;
+      width: 100%; }
+      #main .search--content:last-child {
+        margin-right: 0; } }
+  #main .search--content h2 {
+    border-bottom: none; }
+  #main .search--content a {
+    color: #00BFE7;
+    font-weight: 800; }
+  #main .search--content .search--box {
+    margin: 30px 0; }
+#main footer {
+  margin-top: 1em; }
   #main footer div.left {
     float: left;
     display: block;
@@ -770,7 +748,7 @@ div#usa {
         float: left;
         display: block;
         margin-right: 2.1276595745%;
-        width: 14.8936170213%; }
+        width: 6.3829787234%; }
         #main footer div.left:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
@@ -783,8 +761,7 @@ div#usa {
           margin-right: 0; } }
     #main footer div.left img {
       width: 100%;
-      height: 100%;
-      vertical-align: top; }
+      height: 100%; }
   #main footer div.right {
     float: left;
     display: block;
@@ -876,7 +853,7 @@ div#usa {
         width: 100%; }
         .hero > .container > .hero--content:last-child {
           margin-right: 0; } }
-    .hero > .container > .hero--content p {
+    .hero > .container > .hero--content p.big {
       font-size: 2em;
       line-height: 1.25;
       font-weight: 600;
@@ -888,24 +865,6 @@ div#usa {
 @media screen and (max-width: 30em) {
   .hero {
     padding: 2em 0; } }
-#main.home section.process ul {
-  margin-top: 30px; }
-  #main.home section.process ul figure {
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 24.2105263158%;
-    padding: 0;
-    margin: 0;
-    padding: 10px; }
-    #main.home section.process ul figure:last-child {
-      margin-right: 0; }
-    #main.home section.process ul figure img {
-      width: 100%; }
-    #main.home section.process ul figure figcaption {
-      font-size: 11pt;
-      line-height: 24px; }
-
 #main.agencies ul {
   padding: 0; }
   #main.agencies ul a {
@@ -1138,18 +1097,27 @@ form.request input[type=submit] {
   background-color: #0078e7;
   border-radius: 2px; }
 
-a {
-  color: #18f;
-  text-decoration: none; }
-
 a:hover {
   text-decoration: underline; }
 
 p a:hover {
   text-decoration: underline; }
 
-input.search, input.agency {
+input.agency {
   width: 100%; }
+
+.search input {
+  color: #323A45;
+  width: 100%;
+  background-color: white;
+  display: inline-block; }
+
+.search button {
+  background-color: #00BFE7;
+  color: #323A45;
+  display: inline-block;
+  width: 5%;
+  min-width: 6em; }
 
 .pure-menu .pure-menu-selected a {
   border-bottom: 0.3em solid #333; }
@@ -1225,6 +1193,7 @@ div.request.error {
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2); }
 
 .tt-suggestion {
+  color: #323A45;
   padding: 8px 20px;
   font-size: 18px;
   line-height: 24px; }

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -386,7 +386,7 @@ body {
   -webkit-font-smoothing: antialiased;
   background-color: white;
   color: #333;
-  font-family: "Proxima Nova", sans-serif;
+  font-family: "proxima-nova", "open sans", arial, sans-serif;
   font-size: 1em;
   line-height: 1.5; }
 
@@ -396,7 +396,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Proxima Nova", sans-serif;
+  font-family: "proxima-nova", "open sans", arial, sans-serif;
   line-height: 1.25;
   margin: 0;
   text-rendering: optimizeLegibility; }
@@ -468,7 +468,7 @@ input,
 label,
 select {
   display: block;
-  font-family: "Proxima Nova", sans-serif;
+  font-family: "proxima-nova", "open sans", arial, sans-serif;
   font-size: 1em; }
 
 label {
@@ -492,7 +492,7 @@ select[multiple=multiple] {
   border-radius: 3px;
   border: 1px solid #DDD;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
-  font-family: "Proxima Nova", sans-serif;
+  font-family: "proxima-nova", "open sans", arial, sans-serif;
   font-size: 1em;
   margin-bottom: 0.75em;
   padding: 0.5em 0.5em;
@@ -1159,12 +1159,6 @@ form.request input[type=submit] {
   border: 0;
   background-color: #0078e7;
   border-radius: 2px; }
-
-html, button, input, select, textarea {
-  font-family: 'Open Sans', sans-serif; }
-
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Raleway', sans-serif; }
 
 a {
   color: #18f;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*! normalize.css v3.0.2 | MIT License | git.io/normalize */
 /**
  * 1. Set default font family to sans-serif.
@@ -369,6 +370,228 @@ html {
   -webkit-box-sizing: inherit;
   -moz-box-sizing: inherit;
   box-sizing: inherit; }
+
+/* Bitters 0.10.0
+ * http://bitters.bourbon.io
+ * Copyright 2013–2014 thoughtbot, inc.
+ * MIT License */
+button,
+input[type="submit"] {
+  -webkit-font-smoothing: antialiased;
+  background-color: #477DCA;
+  border-radius: 3px;
+  color: white;
+  display: inline-block;
+  font-size: 1em;
+  font-weight: bold;
+  line-height: 1;
+  padding: 0.75em 1em;
+  text-decoration: none; }
+  button:hover,
+  input[type="submit"]:hover {
+    background-color: #2c5999;
+    color: white; }
+  button:disabled,
+  input[type="submit"]:disabled {
+    cursor: not-allowed;
+    opacity: 0.5; }
+
+body {
+  -webkit-font-smoothing: antialiased;
+  background-color: white;
+  color: #333;
+  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-size: 1em;
+  line-height: 1.5; }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  line-height: 1.25;
+  margin: 0;
+  text-rendering: optimizeLegibility; }
+
+h1 {
+  font-size: 2.25em; }
+
+h2 {
+  font-size: 2em; }
+
+h3 {
+  font-size: 1.75em; }
+
+h4 {
+  font-size: 1.5em; }
+
+h5 {
+  font-size: 1.25em; }
+
+h6 {
+  font-size: 1em; }
+
+p {
+  margin: 0 0 0.75em; }
+
+a {
+  -webkit-transition: color 0.1s linear;
+  -moz-transition: color 0.1s linear;
+  transition: color 0.1s linear;
+  color: #477DCA;
+  text-decoration: none; }
+  a:hover {
+    color: #2c5999; }
+  a:active, a:focus {
+    color: #2c5999;
+    outline: none; }
+
+hr {
+  border-bottom: 1px solid #DDD;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  margin: 1.5em 0; }
+
+img,
+picture {
+  margin: 0;
+  max-width: 100%; }
+
+blockquote {
+  border-left: 2px solid #DDD;
+  color: #595959;
+  margin: 1.5em 0;
+  padding-left: 0.75em; }
+
+cite {
+  color: #737373;
+  font-style: italic; }
+  cite:before {
+    content: "\2014 \00A0"; }
+
+fieldset {
+  background: #f7f7f7;
+  border: 1px solid #DDD;
+  margin: 0 0 0.75em 0;
+  padding: 1.5em; }
+
+input,
+label,
+select {
+  display: block;
+  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-size: 1em; }
+
+label {
+  font-weight: bold;
+  margin-bottom: 0.375em; }
+  label.required:after {
+    content: "*"; }
+  label abbr {
+    display: none; }
+
+textarea,
+input[type="email"], input[type="number"], input[type="password"], input[type="search"], input[type="tel"], input[type="text"], input[type="url"], input[type="color"], input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="month"], input[type="time"], input[type="week"],
+select[multiple=multiple] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  -webkit-transition: border-color;
+  -moz-transition: border-color;
+  transition: border-color;
+  background-color: white;
+  border-radius: 3px;
+  border: 1px solid #DDD;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-size: 1em;
+  margin-bottom: 0.75em;
+  padding: 0.5em 0.5em;
+  width: 100%; }
+  textarea:hover,
+  input[type="email"]:hover, input[type="number"]:hover, input[type="password"]:hover, input[type="search"]:hover, input[type="tel"]:hover, input[type="text"]:hover, input[type="url"]:hover, input[type="color"]:hover, input[type="date"]:hover, input[type="datetime"]:hover, input[type="datetime-local"]:hover, input[type="month"]:hover, input[type="time"]:hover, input[type="week"]:hover,
+  select[multiple=multiple]:hover {
+    border-color: #c4c4c4; }
+  textarea:focus,
+  input[type="email"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="text"]:focus, input[type="url"]:focus, input[type="color"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus,
+  select[multiple=multiple]:focus {
+    border-color: #477DCA;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 5px rgba(55, 112, 192, 0.7);
+    outline: none; }
+
+textarea {
+  resize: vertical; }
+
+input[type="search"] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  -o-appearance: none;
+  appearance: none; }
+
+input[type="checkbox"],
+input[type="radio"] {
+  display: inline;
+  margin-right: 0.375em; }
+
+input[type="file"] {
+  padding-bottom: 0.75em;
+  width: 100%; }
+
+select {
+  margin-bottom: 1.5em;
+  max-width: 100%;
+  width: auto; }
+
+table {
+  border-collapse: collapse;
+  margin: 0.75em 0;
+  table-layout: fixed;
+  width: 100%; }
+
+th {
+  border-bottom: 1px solid #b7b7b7;
+  font-weight: bold;
+  padding: 0.75em 0;
+  text-align: left; }
+
+td {
+  border-bottom: 1px solid #DDD;
+  padding: 0.75em 0; }
+
+tr,
+td,
+th {
+  vertical-align: middle; }
+
+ul,
+ol {
+  margin: 0;
+  padding: 0;
+  list-style-type: none; }
+dl {
+  margin-bottom: 0.75em; }
+  dl dt {
+    font-weight: bold;
+    margin-top: 0.75em; }
+  dl dd {
+    margin: 0; }
+
+button,
+input[type="submit"] {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  -ms-appearance: none;
+  -o-appearance: none;
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap; }
 
 body {
   padding-bottom: 20px; }

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -357,20 +357,6 @@ td,
 th {
   padding: 0; }
 
-/* Neat 1.7.0
- * http://neat.bourbon.io
- * Copyright 2012-2014 thoughtbot, inc.
- * MIT License */
-html {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box; }
-
-*, *:before, *:after {
-  -webkit-box-sizing: inherit;
-  -moz-box-sizing: inherit;
-  box-sizing: inherit; }
-
 /* Bitters 0.10.0
  * http://bitters.bourbon.io
  * Copyright 2013–2014 thoughtbot, inc.
@@ -400,7 +386,7 @@ body {
   -webkit-font-smoothing: antialiased;
   background-color: white;
   color: #333;
-  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-family: "Proxima Nova", sans-serif;
   font-size: 1em;
   line-height: 1.5; }
 
@@ -410,7 +396,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-family: "Proxima Nova", sans-serif;
   line-height: 1.25;
   margin: 0;
   text-rendering: optimizeLegibility; }
@@ -482,7 +468,7 @@ input,
 label,
 select {
   display: block;
-  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-family: "Proxima Nova", sans-serif;
   font-size: 1em; }
 
 label {
@@ -506,7 +492,7 @@ select[multiple=multiple] {
   border-radius: 3px;
   border: 1px solid #DDD;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
-  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-family: "Proxima Nova", sans-serif;
   font-size: 1em;
   margin-bottom: 0.75em;
   padding: 0.5em 0.5em;
@@ -593,11 +579,70 @@ input[type="submit"] {
   vertical-align: middle;
   white-space: nowrap; }
 
+/* Neat 1.7.0
+ * http://neat.bourbon.io
+ * Copyright 2012-2014 thoughtbot, inc.
+ * MIT License */
+html {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box; }
+
+*, *:before, *:after {
+  -webkit-box-sizing: inherit;
+  -moz-box-sizing: inherit;
+  box-sizing: inherit; }
+
+body:before {
+  content: '';
+  display: inline-block;
+  background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+  background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+  background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+  background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+  background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+  height: 100%;
+  left: 0;
+  margin: 0 auto;
+  max-width: 68em;
+  opacity: 0.4;
+  position: fixed;
+  right: 0;
+  width: 100%;
+  pointer-events: none;
+  z-index: -1; }
+  @media screen and (max-width: 61.25em) {
+    body:before {
+      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%);
+      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 3.1578947368%, transparent 3.1578947368%, transparent 4.2105263158%, #EEE 4.2105263158%, #EEE 7.3684210526%, transparent 7.3684210526%, transparent 8.4210526316%, #EEE 8.4210526316%, #EEE 11.5789473684%, transparent 11.5789473684%, transparent 12.6315789474%, #EEE 12.6315789474%, #EEE 15.7894736842%, transparent 15.7894736842%, transparent 16.8421052632%, #EEE 16.8421052632%, #EEE 20%, transparent 20%, transparent 21.0526315789%, #EEE 21.0526315789%, #EEE 24.2105263158%, transparent 24.2105263158%, transparent 25.2631578947%, #EEE 25.2631578947%, #EEE 28.4210526316%, transparent 28.4210526316%, transparent 29.4736842105%, #EEE 29.4736842105%, #EEE 32.6315789474%, transparent 32.6315789474%, transparent 33.6842105263%, #EEE 33.6842105263%, #EEE 36.8421052632%, transparent 36.8421052632%, transparent 37.8947368421%, #EEE 37.8947368421%, #EEE 41.0526315789%, transparent 41.0526315789%, transparent 42.1052631579%, #EEE 42.1052631579%, #EEE 45.2631578947%, transparent 45.2631578947%, transparent 46.3157894737%, #EEE 46.3157894737%, #EEE 49.4736842105%, transparent 49.4736842105%, transparent 50.5263157895%, #EEE 50.5263157895%, #EEE 53.6842105263%, transparent 53.6842105263%, transparent 54.7368421053%, #EEE 54.7368421053%, #EEE 57.8947368421%, transparent 57.8947368421%, transparent 58.9473684211%, #EEE 58.9473684211%, #EEE 62.1052631579%, transparent 62.1052631579%, transparent 63.1578947368%, #EEE 63.1578947368%, #EEE 66.3157894737%, transparent 66.3157894737%, transparent 67.3684210526%, #EEE 67.3684210526%, #EEE 70.5263157895%, transparent 70.5263157895%, transparent 71.5789473684%, #EEE 71.5789473684%, #EEE 74.7368421053%, transparent 74.7368421053%, transparent 75.7894736842%, #EEE 75.7894736842%, #EEE 78.9473684211%, transparent 78.9473684211%, transparent 80.0%, #EEE 80.0%, #EEE 83.1578947368%, transparent 83.1578947368%, transparent 84.2105263158%, #EEE 84.2105263158%, #EEE 87.3684210526%, transparent 87.3684210526%, transparent 88.4210526316%, #EEE 88.4210526316%, #EEE 91.5789473684%, transparent 91.5789473684%, transparent 92.6315789474%, #EEE 92.6315789474%, #EEE 95.7894736842%, transparent 95.7894736842%, transparent 96.8421052632%, #EEE 96.8421052632%, #EEE 100.0%, transparent 100.0%); } }
+  @media screen and (max-width: 48em) {
+    body:before {
+      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
+      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
+      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
+      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%);
+      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 6.3829787234%, transparent 6.3829787234%, transparent 8.5106382979%, #EEE 8.5106382979%, #EEE 14.8936170213%, transparent 14.8936170213%, transparent 17.0212765957%, #EEE 17.0212765957%, #EEE 23.4042553191%, transparent 23.4042553191%, transparent 25.5319148936%, #EEE 25.5319148936%, #EEE 31.914893617%, transparent 31.914893617%, transparent 34.0425531915%, #EEE 34.0425531915%, #EEE 40.4255319149%, transparent 40.4255319149%, transparent 42.5531914894%, #EEE 42.5531914894%, #EEE 48.9361702128%, transparent 48.9361702128%, transparent 51.0638297872%, #EEE 51.0638297872%, #EEE 57.4468085106%, transparent 57.4468085106%, transparent 59.5744680851%, #EEE 59.5744680851%, #EEE 65.9574468085%, transparent 65.9574468085%, transparent 68.085106383%, #EEE 68.085106383%, #EEE 74.4680851064%, transparent 74.4680851064%, transparent 76.5957446809%, #EEE 76.5957446809%, #EEE 82.9787234043%, transparent 82.9787234043%, transparent 85.1063829787%, #EEE 85.1063829787%, #EEE 91.4893617021%, transparent 91.4893617021%, transparent 93.6170212766%, #EEE 93.6170212766%, #EEE 100.0%, transparent 100.0%); } }
+  @media screen and (max-width: 30em) {
+    body:before {
+      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%); } }
+  @media screen and (max-width: 20em) {
+    body:before {
+      background-image: -webkit-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: -moz-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: -ms-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: -o-linear-gradient(left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%);
+      background-image: linear-gradient(to left, transparent 0, #EEE 0, #EEE 20%, transparent 20%, transparent 26.6666666667%, #EEE 26.6666666667%, #EEE 46.6666666667%, transparent 46.6666666667%, transparent 53.3333333333%, #EEE 53.3333333333%, #EEE 73.3333333333%, transparent 73.3333333333%, transparent 80.0%, #EEE 80.0%, #EEE 100.0%, transparent 100.0%); } }
+
 body {
   padding-bottom: 20px; }
 
-/* a couple things that stand outside the normal hierarchy, because
-   they extend the full width, beyond the normal outer-container */
 body > header {
   border-bottom: 1px solid #dedede; }
   body > header a:hover {
@@ -605,8 +650,8 @@ body > header {
   body > header h1 {
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 24.1261814493%;
+    margin-right: 1.0526315789%;
+    width: 24.2105263158%;
     font-weight: normal;
     font-size: 2em;
     color: #18f; }
@@ -622,9 +667,9 @@ body > header {
   body > header nav {
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 40.9870300161%;
-    margin-left: 33.7216971337%; }
+    margin-right: 1.0526315789%;
+    width: 41.0526315789%;
+    margin-left: 33.6842105263%; }
     body > header nav:last-child {
       margin-right: 0; }
     body > header nav ul li {
@@ -671,20 +716,38 @@ div#usa {
   #main .content {
     padding-top: 20px; }
   #main section.search {
-    margin-left: 16.8608485668%;
+    margin-left: 16.8421052632%;
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 66.2783028663%;
+    margin-right: 1.0526315789%;
+    width: 66.3157894737%;
     padding: 70px 0; }
     #main section.search:last-child {
       margin-right: 0; }
+    @media screen and (max-width: 61.25em) {
+      #main section.search {
+        margin-left: 8.4210526316%;
+        float: left;
+        display: block;
+        margin-right: 1.0526315789%;
+        width: 83.1578947368%; }
+        #main section.search:last-child {
+          margin-right: 0; } }
+    @media screen and (max-width: 48em) {
+      #main section.search {
+        margin-left: 4.2105263158%;
+        float: left;
+        display: block;
+        margin-right: 2.1276595745%;
+        width: 82.9787234043%; }
+        #main section.search:last-child {
+          margin-right: 0; } }
     @media screen and (max-width: 30em) {
       #main section.search {
         margin-left: 0%;
         float: left;
         display: block;
-        margin-right: 7.4229703521%;
+        margin-right: 6.6666666667%;
         width: 100%; }
         #main section.search:last-child {
           margin-right: 0; } }
@@ -710,24 +773,24 @@ div#usa {
   #main footer div.left {
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 11.4805450242%; }
+    margin-right: 1.0526315789%;
+    width: 11.5789473684%; }
     #main footer div.left:last-child {
       margin-right: 0; }
     @media screen and (max-width: 48em) {
       #main footer div.left {
         float: left;
         display: block;
-        margin-right: 2.3576515979%;
-        width: 23.2317613015%; }
+        margin-right: 2.1276595745%;
+        width: 23.4042553191%; }
         #main footer div.left:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
       #main footer div.left {
         float: left;
         display: block;
-        margin-right: 7.4229703521%;
-        width: 19.432772236%; }
+        margin-right: 6.6666666667%;
+        width: 20%; }
         #main footer div.left:last-child {
           margin-right: 0; } }
     #main footer div.left img {
@@ -738,29 +801,29 @@ div#usa {
   #main footer div.right {
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 87.3543635749%; }
+    margin-right: 1.0526315789%;
+    width: 87.3684210526%; }
     #main footer div.right:last-child {
       margin-right: 0; }
     @media screen and (max-width: 48em) {
       #main footer div.right {
         float: left;
         display: block;
-        margin-right: 2.3576515979%;
-        width: 74.4105871005%; }
+        margin-right: 2.1276595745%;
+        width: 74.4680851064%; }
         #main footer div.right:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
       #main footer div.right {
         float: left;
         display: block;
-        margin-right: 7.4229703521%;
-        width: 73.144257412%; }
+        margin-right: 6.6666666667%;
+        width: 73.3333333333%; }
         #main footer div.right:last-child {
           margin-right: 0; } }
 
 .container {
-  max-width: 64em;
+  max-width: 68em;
   margin-left: auto;
   margin-right: auto;
   padding: 0 1.5em; }
@@ -772,7 +835,7 @@ div#usa {
 .row {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
+  margin-right: 1.0526315789%;
   width: 100%; }
   .row:last-child {
     margin-right: 0; }
@@ -791,19 +854,37 @@ div#usa {
   padding: 2em 0;
   background-size: contain; }
   .hero > .container > .hero--content {
-    margin-left: 16.8608485668%;
+    margin-left: 16.8421052632%;
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 66.2783028663%; }
+    margin-right: 1.0526315789%;
+    width: 66.3157894737%; }
     .hero > .container > .hero--content:last-child {
       margin-right: 0; }
+    @media screen and (max-width: 61.25em) {
+      .hero > .container > .hero--content {
+        margin-left: 8.4210526316%;
+        float: left;
+        display: block;
+        margin-right: 1.0526315789%;
+        width: 83.1578947368%; }
+        .hero > .container > .hero--content:last-child {
+          margin-right: 0; } }
+    @media screen and (max-width: 48em) {
+      .hero > .container > .hero--content {
+        margin-left: 4.2105263158%;
+        float: left;
+        display: block;
+        margin-right: 2.1276595745%;
+        width: 82.9787234043%; }
+        .hero > .container > .hero--content:last-child {
+          margin-right: 0; } }
     @media screen and (max-width: 30em) {
       .hero > .container > .hero--content {
         margin-left: 0%;
         float: left;
         display: block;
-        margin-right: 7.4229703521%;
+        margin-right: 6.6666666667%;
         width: 100%; }
         .hero > .container > .hero--content:last-child {
           margin-right: 0; } }
@@ -827,8 +908,8 @@ div#usa {
   #main.home section.process ul figure {
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 24.1261814493%;
+    margin-right: 1.0526315789%;
+    width: 24.2105263158%;
     padding: 0;
     margin: 0;
     padding: 10px; }
@@ -852,22 +933,22 @@ div#usa {
     margin-bottom: 50px;
     float: left;
     display: block;
-    margin-right: 1.165091401%;
+    margin-right: 1.0526315789%;
     width: 100%; }
     #main.agencies ul li:last-child {
       margin-right: 0; }
     #main.agencies ul li .agencies--name {
       float: left;
       display: block;
-      margin-right: 1.165091401%;
-      width: 32.5566057327%; }
+      margin-right: 1.0526315789%;
+      width: 32.6315789474%; }
       #main.agencies ul li .agencies--name:last-child {
         margin-right: 0; }
       @media screen and (max-width: 30em) {
         #main.agencies ul li .agencies--name {
           float: left;
           display: block;
-          margin-right: 7.4229703521%;
+          margin-right: 6.6666666667%;
           width: 100%; }
           #main.agencies ul li .agencies--name:last-child {
             margin-right: 0; } }
@@ -881,15 +962,15 @@ div#usa {
     #main.agencies ul li .agencies--description {
       float: left;
       display: block;
-      margin-right: 1.165091401%;
-      width: 66.2783028663%; }
+      margin-right: 1.0526315789%;
+      width: 66.3157894737%; }
       #main.agencies ul li .agencies--description:last-child {
         margin-right: 0; }
       @media screen and (max-width: 30em) {
         #main.agencies ul li .agencies--description {
           float: left;
           display: block;
-          margin-right: 7.4229703521%;
+          margin-right: 6.6666666667%;
           width: 100%; }
           #main.agencies ul li .agencies--description:last-child {
             margin-right: 0; } }
@@ -922,30 +1003,30 @@ div#usa {
 #main.landing .department .description {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
-  width: 57.8478785829%; }
+  margin-right: 1.0526315789%;
+  width: 57.8947368421%; }
   #main.landing .department .description:last-child {
     margin-right: 0; }
   @media screen and (max-width: 30em) {
     #main.landing .department .description {
       float: left;
       display: block;
-      margin-right: 7.4229703521%;
+      margin-right: 6.6666666667%;
       width: 100%; }
       #main.landing .department .description:last-child {
         margin-right: 0; } }
 #main.landing .department .resources {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
-  width: 40.9870300161%; }
+  margin-right: 1.0526315789%;
+  width: 41.0526315789%; }
   #main.landing .department .resources:last-child {
     margin-right: 0; }
   @media screen and (max-width: 30em) {
     #main.landing .department .resources {
       float: left;
       display: block;
-      margin-right: 7.4229703521%;
+      margin-right: 6.6666666667%;
       width: 100%;
       padding-left: none; }
       #main.landing .department .resources:last-child {
@@ -959,30 +1040,30 @@ div#usa {
 #main.landing .details .offices, #main.landing .details .left {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
-  width: 57.8478785829%; }
+  margin-right: 1.0526315789%;
+  width: 57.8947368421%; }
   #main.landing .details .offices:last-child, #main.landing .details .left:last-child {
     margin-right: 0; }
   @media screen and (max-width: 30em) {
     #main.landing .details .offices, #main.landing .details .left {
       float: left;
       display: block;
-      margin-right: 7.4229703521%;
+      margin-right: 6.6666666667%;
       width: 100%; }
       #main.landing .details .offices:last-child, #main.landing .details .left:last-child {
         margin-right: 0; } }
 #main.landing .details .contact, #main.landing .details .right {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
-  width: 40.9870300161%; }
+  margin-right: 1.0526315789%;
+  width: 41.0526315789%; }
   #main.landing .details .contact:last-child, #main.landing .details .right:last-child {
     margin-right: 0; }
   @media screen and (max-width: 30em) {
     #main.landing .details .contact, #main.landing .details .right {
       float: left;
       display: block;
-      margin-right: 7.4229703521%;
+      margin-right: 6.6666666667%;
       width: 100%; }
       #main.landing .details .contact:last-child, #main.landing .details .right:last-child {
         margin-right: 0; } }
@@ -995,8 +1076,8 @@ div#usa {
   #main.landing .resource_type .icon, #main.landing .contact_type .icon {
     float: left;
     display: block;
-    margin-right: 1.165091401%;
-    width: 7.2653328825%;
+    margin-right: 1.0526315789%;
+    width: 7.3684210526%;
     font-size: 0.95em;
     text-align: center;
     margin-right: 1em; }
@@ -1039,8 +1120,8 @@ form.request input.upto[type=text] {
 form.request fieldset {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
-  width: 49.4174542995%;
+  margin-right: 1.0526315789%;
+  width: 49.4736842105%;
   border: 0; }
   form.request fieldset:last-child {
     margin-right: 0; }
@@ -1057,8 +1138,8 @@ form.request fieldset {
 form.request #name-email input {
   float: left;
   display: block;
-  margin-right: 1.165091401%;
-  width: 49.4174542995%;
+  margin-right: 1.0526315789%;
+  width: 49.4736842105%;
   margin: 0; }
   form.request #name-email input:last-child {
     margin-right: 0; }

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -364,7 +364,7 @@ th {
 button,
 input[type="submit"] {
   -webkit-font-smoothing: antialiased;
-  background-color: #477DCA;
+  background-color: #0096B5;
   border-radius: 3px;
   color: white;
   display: inline-block;
@@ -375,7 +375,7 @@ input[type="submit"] {
   text-decoration: none; }
   button:hover,
   input[type="submit"]:hover {
-    background-color: #2c5999;
+    background-color: #005769;
     color: white; }
   button:disabled,
   input[type="submit"]:disabled {
@@ -385,7 +385,7 @@ input[type="submit"] {
 body {
   -webkit-font-smoothing: antialiased;
   background-color: white;
-  color: #333;
+  color: #323A45;
   font-family: "proxima-nova", "open sans", arial, sans-serif;
   font-size: 1em;
   line-height: 1.5; }
@@ -399,13 +399,15 @@ h6 {
   font-family: "proxima-nova", "open sans", arial, sans-serif;
   line-height: 1.25;
   margin: 0;
-  text-rendering: optimizeLegibility; }
+  text-rendering: optimizeLegibility;
+  display: inline-block; }
 
 h1 {
   font-size: 2.25em; }
 
 h2 {
-  font-size: 2em; }
+  font-size: 2em;
+  border-bottom: 0.2em solid #00BFE7; }
 
 h3 {
   font-size: 1.75em; }
@@ -426,16 +428,16 @@ a {
   -webkit-transition: color 0.1s linear;
   -moz-transition: color 0.1s linear;
   transition: color 0.1s linear;
-  color: #477DCA;
+  color: #0096B5;
   text-decoration: none; }
   a:hover {
-    color: #2c5999; }
+    color: #005769; }
   a:active, a:focus {
-    color: #2c5999;
+    color: #005769;
     outline: none; }
 
 hr {
-  border-bottom: 1px solid #DDD;
+  border-bottom: 1px solid #323A45;
   border-left: none;
   border-right: none;
   border-top: none;
@@ -447,20 +449,20 @@ picture {
   max-width: 100%; }
 
 blockquote {
-  border-left: 2px solid #DDD;
-  color: #595959;
+  border-left: 2px solid #323A45;
+  color: #525f71;
   margin: 1.5em 0;
   padding-left: 0.75em; }
 
 cite {
-  color: #737373;
+  color: #68788f;
   font-style: italic; }
   cite:before {
     content: "\2014 \00A0"; }
 
 fieldset {
-  background: #f7f7f7;
-  border: 1px solid #DDD;
+  background: #475363;
+  border: 1px solid #323A45;
   margin: 0 0 0.75em 0;
   padding: 1.5em; }
 
@@ -490,7 +492,7 @@ select[multiple=multiple] {
   transition: border-color;
   background-color: white;
   border-radius: 3px;
-  border: 1px solid #DDD;
+  border: 1px solid #323A45;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
   font-family: "proxima-nova", "open sans", arial, sans-serif;
   font-size: 1em;
@@ -500,12 +502,12 @@ select[multiple=multiple] {
   textarea:hover,
   input[type="email"]:hover, input[type="number"]:hover, input[type="password"]:hover, input[type="search"]:hover, input[type="tel"]:hover, input[type="text"]:hover, input[type="url"]:hover, input[type="color"]:hover, input[type="date"]:hover, input[type="datetime"]:hover, input[type="datetime-local"]:hover, input[type="month"]:hover, input[type="time"]:hover, input[type="week"]:hover,
   select[multiple=multiple]:hover {
-    border-color: #c4c4c4; }
+    border-color: #1d2127; }
   textarea:focus,
   input[type="email"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="text"]:focus, input[type="url"]:focus, input[type="color"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus,
   select[multiple=multiple]:focus {
-    border-color: #477DCA;
-    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 5px rgba(55, 112, 192, 0.7);
+    border-color: #0096B5;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06), 0 0 5px rgba(0, 129, 156, 0.7);
     outline: none; }
 
 textarea {
@@ -539,13 +541,13 @@ table {
   width: 100%; }
 
 th {
-  border-bottom: 1px solid #b7b7b7;
+  border-bottom: 1px solid #121519;
   font-weight: bold;
   padding: 0.75em 0;
   text-align: left; }
 
 td {
-  border-bottom: 1px solid #DDD;
+  border-bottom: 1px solid #323A45;
   padding: 0.75em 0; }
 
 tr,
@@ -644,48 +646,36 @@ body {
   padding-bottom: 20px; }
 
 body > header {
-  border-bottom: 1px solid #dedede; }
+  border-bottom: 1px solid #dedede;
+  /* Wordmark */ }
   body > header a:hover {
     text-decoration: none; }
   body > header h1 {
     float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 24.2105263158%;
     font-weight: normal;
     font-size: 2em;
-    color: #18f; }
-    body > header h1:last-child {
-      margin-right: 0; }
+    color: #0096B5; }
     body > header h1 a {
-      color: #18f; }
+      color: #0096B5; }
     body > header h1 strong {
       font-weight: 800; }
     body > header h1 em {
       color: #cc2211;
       font-style: normal; }
-  body > header nav {
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 41.0526315789%;
-    margin-left: 33.6842105263%; }
-    body > header nav:last-child {
-      margin-right: 0; }
-    body > header nav ul li {
-      display: inline-block;
-      padding: 9px 12px 0 12px; }
-    body > header nav ul a {
-      color: #333;
-      padding: 5px 0px 25px 0px; }
-    body > header nav ul a:hover, body > header nav ul a.active {
-      border-bottom: 0.3em solid #777; }
-    body > header nav ul a:hover {
-      background: none;
-      color: #777; }
-    body > header nav ul a:focus {
-      background: #fff;
-      color: #1188ff; }
+  body > header nav ul li {
+    display: inline-block;
+    padding: 9px 10px 0 10px; }
+  body > header nav ul a {
+    color: #333;
+    padding: 0 0px 6px 0; }
+  body > header nav ul a:hover, body > header nav ul a.active {
+    border-bottom: 0.3em solid #00BFE7; }
+  body > header nav ul a:hover {
+    background: none;
+    color: #777; }
+  body > header nav ul a:focus {
+    background: #fff;
+    color: #1188ff; }
 
 /* 
  * Mixin: inner 
@@ -700,81 +690,80 @@ body > header {
  * $columns should always be an even number 
  */
 div#usa {
-  background-color: rgba(0, 0, 0, 0.75); }
+  background-color: #323A45;
+  color: #EAEDF1; }
   div#usa .usa--content {
     padding-top: 0.75em;
-    margin-bottom: 0.8em;
-    color: #ddd;
-    text-align: center; }
-    div#usa .usa--content h4 {
-      font-size: 0.75em;
-      font-weight: 500;
-      margin: 0.4em 0; }
+    margin-bottom: 0.8em; }
+  div#usa .official {
+    float: left; }
+  div#usa .alpha {
+    float: right; }
+  @media screen and (max-width: 48em) {
+    div#usa .official, div#usa .alpha {
+      float: none;
+      text-align: center; } }
 
 #main {
   /* /about and /learn */ }
   #main .content {
     padding-top: 20px; }
-  #main section.search {
+  #main .search {
+    background: #323A45;
+    color: #EAEDF1; }
+  #main .search--content {
     margin-left: 16.8421052632%;
     float: left;
     display: block;
     margin-right: 1.0526315789%;
-    width: 66.3157894737%;
-    padding: 70px 0; }
-    #main section.search:last-child {
+    width: 66.3157894737%; }
+    #main .search--content:last-child {
       margin-right: 0; }
     @media screen and (max-width: 61.25em) {
-      #main section.search {
+      #main .search--content {
         margin-left: 8.4210526316%;
         float: left;
         display: block;
         margin-right: 1.0526315789%;
         width: 83.1578947368%; }
-        #main section.search:last-child {
+        #main .search--content:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 48em) {
-      #main section.search {
+      #main .search--content {
         margin-left: 4.2105263158%;
         float: left;
         display: block;
         margin-right: 2.1276595745%;
         width: 82.9787234043%; }
-        #main section.search:last-child {
+        #main .search--content:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
-      #main section.search {
+      #main .search--content {
         margin-left: 0%;
         float: left;
         display: block;
         margin-right: 6.6666666667%;
         width: 100%; }
-        #main section.search:last-child {
+        #main .search--content:last-child {
           margin-right: 0; } }
-    #main section.search h2 {
+    #main .search--content h2 {
       text-align: center;
       font-weight: normal;
-      font-size: 28pt;
       margin: 0;
-      padding: 0; }
-    #main section.search p {
-      margin-top: 30px;
-      font-size: 18pt;
-      line-height: 36px; }
-    #main section.search .search-box {
+      padding: 0;
+      border-bottom: none; }
+    #main .search--content p {
       margin-top: 30px; }
-    #main section.search p.browse {
+    #main .search--content .search-box {
+      margin-top: 30px; }
+    #main .search--content p.browse {
       margin-top: 15px;
-      font-size: 10pt;
-      line-height: 20px;
       text-align: center; }
-    #main section.search hr {
-      margin-top: 80px; }
   #main footer div.left {
     float: left;
     display: block;
     margin-right: 1.0526315789%;
-    width: 11.5789473684%; }
+    width: 7.3684210526%; }
     #main footer div.left:last-child {
       margin-right: 0; }
     @media screen and (max-width: 48em) {
@@ -782,7 +771,7 @@ div#usa {
         float: left;
         display: block;
         margin-right: 2.1276595745%;
-        width: 23.4042553191%; }
+        width: 14.8936170213%; }
         #main footer div.left:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
@@ -794,15 +783,15 @@ div#usa {
         #main footer div.left:last-child {
           margin-right: 0; } }
     #main footer div.left img {
-      width: 100px;
-      height: 100px;
-      margin: 10px 0;
+      width: 100%;
+      height: 100%;
       vertical-align: top; }
   #main footer div.right {
     float: left;
     display: block;
     margin-right: 1.0526315789%;
-    width: 87.3684210526%; }
+    width: 87.3684210526%;
+    margin-left: 4.2105263158%; }
     #main footer div.right:last-child {
       margin-right: 0; }
     @media screen and (max-width: 48em) {
@@ -810,7 +799,8 @@ div#usa {
         float: left;
         display: block;
         margin-right: 2.1276595745%;
-        width: 74.4680851064%; }
+        width: 74.4680851064%;
+        margin-left: 0%; }
         #main footer div.right:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
@@ -850,9 +840,8 @@ div#usa {
   clear: both; }
 
 .hero {
-  background-color: #f1f8ff;
-  padding: 2em 0;
-  background-size: contain; }
+  background-color: #EAEDF1;
+  padding: 2em 0; }
   .hero > .container > .hero--content {
     margin-left: 16.8421052632%;
     float: left;
@@ -888,16 +877,10 @@ div#usa {
         width: 100%; }
         .hero > .container > .hero--content:last-child {
           margin-right: 0; } }
-    .hero > .container > .hero--content h2 {
-      text-align: center;
-      font-weight: normal;
-      font-size: 28pt;
-      margin: 0;
-      padding: 0; }
     .hero > .container > .hero--content p {
       /* VZ: This should be moved to a variable. Prob powered by Bitters. */
       margin-top: 30px;
-      font-size: 21pt;
+      font-size: 2em;
       line-height: 40px; }
 
 @media screen and (max-width: 30em) {

--- a/foia_hub/static/sass/base/_base.scss
+++ b/foia_hub/static/sass/base/_base.scss
@@ -1,0 +1,24 @@
+/* Bitters 0.10.0
+ * http://bitters.bourbon.io
+ * Copyright 2013–2014 thoughtbot, inc.
+ * MIT License */
+
+// Variables
+@import "variables";
+
+// Neat Settings -- uncomment if using Neat -- must be imported before Neat
+// @import "grid-settings";
+
+// Extends
+@import "extends/button";
+@import "extends/clearfix";
+@import "extends/errors";
+@import "extends/flashes";
+@import "extends/hide-text";
+
+// Typography and Elements
+@import "typography";
+@import "forms";
+@import "tables";
+@import "lists";
+@import "buttons";

--- a/foia_hub/static/sass/base/_base.scss
+++ b/foia_hub/static/sass/base/_base.scss
@@ -7,7 +7,7 @@
 @import "variables";
 
 // Neat Settings -- uncomment if using Neat -- must be imported before Neat
-// @import "grid-settings";
+@import "grid-settings";
 
 // Extends
 @import "extends/button";

--- a/foia_hub/static/sass/base/_buttons.scss
+++ b/foia_hub/static/sass/base/_buttons.scss
@@ -1,0 +1,10 @@
+button,
+input[type="submit"] {
+  @extend %button;
+  @include appearance(none);
+  border: none;
+  cursor: pointer;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+}

--- a/foia_hub/static/sass/base/_forms.scss
+++ b/foia_hub/static/sass/base/_forms.scss
@@ -1,0 +1,78 @@
+fieldset {
+  background: lighten($base-border-color, 10);
+  border: $base-border;
+  margin: 0 0 ($base-spacing / 2) 0;
+  padding: $base-spacing;
+}
+
+input,
+label,
+select {
+  display: block;
+  font-family: $form-font-family;
+  font-size: $form-font-size;
+}
+
+label {
+  font-weight: bold;
+  margin-bottom: $base-spacing / 4;
+
+  &.required:after {
+    content: "*";
+  }
+
+  abbr {
+    display: none;
+  }
+}
+
+textarea,
+#{$all-text-inputs},
+select[multiple=multiple] {
+  @include box-sizing(border-box);
+  @include transition(border-color);
+  background-color: white;
+  border-radius: $form-border-radius;
+  border: 1px solid $form-border-color;
+  box-shadow: $form-box-shadow;
+  font-family: $form-font-family;
+  font-size: $form-font-size;
+  margin-bottom: $base-spacing / 2;
+  padding: ($base-spacing / 3) ($base-spacing / 3);
+  width: 100%;
+
+  &:hover {
+    border-color: $form-border-color-hover;
+  }
+
+  &:focus {
+    border-color: $form-border-color-focus;
+    box-shadow: $form-box-shadow-focus;
+    outline: none;
+  }
+}
+
+textarea {
+  resize: vertical;
+}
+
+input[type="search"] {
+  @include appearance(none);
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  display: inline;
+  margin-right: $base-spacing / 4;
+}
+
+input[type="file"] {
+  padding-bottom: $base-spacing / 2;
+  width: 100%;
+}
+
+select {
+  margin-bottom: $base-spacing;
+  max-width: 100%;
+  width: auto;
+}

--- a/foia_hub/static/sass/base/_grid-settings.scss
+++ b/foia_hub/static/sass/base/_grid-settings.scss
@@ -1,0 +1,14 @@
+@import "neat-helpers"; // or "../neat/neat-helpers" when not in Rails
+
+// Neat Overrides
+// $column: 90px;
+// $gutter: 30px;
+// $grid-columns: 12;
+// $max-width: em(1088);
+
+// Neat Breakpoints
+$medium-screen: em(640);
+$large-screen: em(860);
+
+$medium-screen-up: new-breakpoint(min-width $medium-screen 4);
+$large-screen-up: new-breakpoint(min-width $large-screen 8);

--- a/foia_hub/static/sass/base/_grid-settings.scss
+++ b/foia_hub/static/sass/base/_grid-settings.scss
@@ -16,7 +16,7 @@
 
 // Krang Overrides
 
-$visual-grid: true;
+// $visual-grid: true;
 // $visual-grid-index: front;
 
 $column: 90px;

--- a/foia_hub/static/sass/base/_grid-settings.scss
+++ b/foia_hub/static/sass/base/_grid-settings.scss
@@ -1,4 +1,4 @@
-@import "neat-helpers"; // or "../neat/neat-helpers" when not in Rails
+@import "../neat/neat-helpers"; // or "../neat/neat-helpers" when not in Rails
 
 // Neat Overrides
 // $column: 90px;
@@ -7,8 +7,28 @@
 // $max-width: em(1088);
 
 // Neat Breakpoints
-$medium-screen: em(640);
-$large-screen: em(860);
+// $medium-screen: em(640);
+// $large-screen: em(860);
 
-$medium-screen-up: new-breakpoint(min-width $medium-screen 4);
-$large-screen-up: new-breakpoint(min-width $large-screen 8);
+// $medium-screen-up: new-breakpoint(min-width $medium-screen 4);
+// $large-screen-up: new-breakpoint(min-width $large-screen 8);
+
+
+// Krang Overrides
+
+$visual-grid: true;
+
+$column: 90px;
+$gutter: 30px;
+$grid-columns: 24;
+$max-width: em(1088);
+
+$extra-small-screen: em(320);
+$small-screen: em(480);
+$medium-screen: em(768);
+$large-screen: em(980);
+
+$large: new-breakpoint(max-width $large-screen 24);
+$medium: new-breakpoint(max-width $medium-screen 12);
+$small: new-breakpoint(max-width $small-screen 4);
+$extra-small: new-breakpoint(max-width $extra-small-screen 4);

--- a/foia_hub/static/sass/base/_grid-settings.scss
+++ b/foia_hub/static/sass/base/_grid-settings.scss
@@ -17,6 +17,7 @@
 // Krang Overrides
 
 $visual-grid: true;
+// $visual-grid-index: front;
 
 $column: 90px;
 $gutter: 30px;

--- a/foia_hub/static/sass/base/_lists.scss
+++ b/foia_hub/static/sass/base/_lists.scss
@@ -1,0 +1,31 @@
+ul,
+ol {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+
+  &%default-ul {
+    list-style-type: disc;
+    margin-bottom: $base-spacing / 2;
+    padding-left: $base-spacing;
+  }
+
+  &%default-ol {
+    list-style-type: decimal;
+    margin-bottom: $base-spacing / 2;
+    padding-left: $base-spacing;
+  }
+}
+
+dl {
+  margin-bottom: $base-spacing / 2;
+
+  dt {
+    font-weight: bold;
+    margin-top: $base-spacing / 2;
+  }
+
+  dd {
+    margin: 0;
+  }
+}

--- a/foia_hub/static/sass/base/_tables.scss
+++ b/foia_hub/static/sass/base/_tables.scss
@@ -1,0 +1,24 @@
+table {
+  border-collapse: collapse;
+  margin: ($base-spacing / 2) 0;
+  table-layout: fixed;
+  width: 100%;
+}
+
+th {
+  border-bottom: 1px solid darken($base-border-color, 15);
+  font-weight: bold;
+  padding: ($base-spacing / 2) 0;
+  text-align: left;
+}
+
+td {
+  border-bottom: $base-border;
+  padding: ($base-spacing / 2) 0;
+}
+
+tr,
+td,
+th {
+  vertical-align: middle;
+}

--- a/foia_hub/static/sass/base/_typography.scss
+++ b/foia_hub/static/sass/base/_typography.scss
@@ -1,0 +1,93 @@
+body {
+  -webkit-font-smoothing: antialiased;
+  background-color: $base-background-color;
+  color: $base-font-color;
+  font-family: $base-font-family;
+  font-size: $base-font-size;
+  line-height: $base-line-height;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: $header-font-family;
+  line-height: $header-line-height;
+  margin: 0;
+  text-rendering: optimizeLegibility; // Fix the character spacing for headings
+}
+
+h1 {
+  font-size: $h1-font-size;
+}
+
+h2 {
+  font-size: $h2-font-size;
+}
+
+h3 {
+  font-size: $h3-font-size;
+}
+
+h4 {
+  font-size: $h4-font-size;
+}
+
+h5 {
+  font-size: $h5-font-size;
+}
+
+h6 {
+  font-size: $h6-font-size;
+}
+
+p {
+  margin: 0 0 ($base-spacing / 2);
+}
+
+a {
+  @include transition(color 0.1s linear);
+  color: $base-link-color;
+  text-decoration: none;
+
+  &:hover {
+    color: $hover-link-color;
+  }
+
+  &:active, &:focus {
+    color: $hover-link-color;
+    outline: none;
+  }
+}
+
+hr {
+  border-bottom: $base-border;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  margin: $base-spacing 0;
+}
+
+img,
+picture {
+  margin: 0;
+  max-width: 100%;
+}
+
+blockquote {
+  border-left: 2px solid $base-border-color;
+  color: lighten($base-font-color, 15);
+  margin: $base-spacing 0;
+  padding-left: $base-spacing / 2;
+}
+
+cite {
+  color: lighten($base-font-color, 25);
+  font-style: italic;
+
+  &:before {
+    content: "\2014 \00A0";
+  }
+}

--- a/foia_hub/static/sass/base/_typography.scss
+++ b/foia_hub/static/sass/base/_typography.scss
@@ -14,6 +14,7 @@ h4,
 h5,
 h6 {
   font-family: $header-font-family;
+  font-weight: $header-font-weight;
   line-height: $header-line-height;
   margin: 0;
   text-rendering: optimizeLegibility; // Fix the character spacing for headings
@@ -26,7 +27,8 @@ h1 {
 
 h2 {
   font-size: $h2-font-size;
-  border-bottom: 0.2em solid $aqua-blue;
+  border-bottom: 0.15em solid $aqua-blue;
+  padding-bottom: 0.2em;
 }
 
 h3 {

--- a/foia_hub/static/sass/base/_typography.scss
+++ b/foia_hub/static/sass/base/_typography.scss
@@ -21,14 +21,27 @@ h6 {
   display: inline-block;
 }
 
+.hero--content {
+  h1, h2, h3, h4, h5, h6
+   {
+      padding-bottom:0.8em; // Krang
+   }
+}
+
 h1 {
   font-size: $h1-font-size;
 }
 
 h2 {
   font-size: $h2-font-size;
-  border-bottom: 0.15em solid $aqua-blue;
-  padding-bottom: 0.2em;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  em {
+    border-bottom: 0.15em solid $aqua-blue;
+    line-height: $header-line-height * 1.25;
+    font-style: normal;
+  }
 }
 
 h3 {

--- a/foia_hub/static/sass/base/_typography.scss
+++ b/foia_hub/static/sass/base/_typography.scss
@@ -17,6 +17,7 @@ h6 {
   line-height: $header-line-height;
   margin: 0;
   text-rendering: optimizeLegibility; // Fix the character spacing for headings
+  display: inline-block;
 }
 
 h1 {
@@ -25,6 +26,7 @@ h1 {
 
 h2 {
   font-size: $h2-font-size;
+  border-bottom: 0.2em solid $aqua-blue;
 }
 
 h3 {

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -1,0 +1,65 @@
+// Typography
+$sans-serif: $helvetica;
+$serif: $georgia;
+$base-font-family: $sans-serif;
+$header-font-family: $base-font-family;
+
+// Font Sizes
+$base-font-size: 1em;
+$h1-font-size: $base-font-size * 2.25;
+$h2-font-size: $base-font-size * 2;
+$h3-font-size: $base-font-size * 1.75;
+$h4-font-size: $base-font-size * 1.5;
+$h5-font-size: $base-font-size * 1.25;
+$h6-font-size: $base-font-size;
+
+// Line height
+$base-line-height: 1.5;
+$header-line-height: 1.25;
+
+// Other Sizes
+$base-border-radius: 3px;
+$base-spacing: $base-line-height * 1em;
+$base-z-index: 0;
+
+// Colors
+$blue: #477DCA;
+$dark-gray: #333;
+$medium-gray: #999;
+$light-gray: #DDD;
+$light-red: #FBE3E4;
+$light-yellow: #FFF6BF;
+$light-green: #E6EFC2;
+
+// Background Color
+$base-background-color: white;
+
+// Font Colors
+$base-font-color: $dark-gray;
+$base-accent-color: $blue;
+
+// Link Colors
+$base-link-color: $base-accent-color;
+$hover-link-color: darken($base-accent-color, 15);
+$base-button-color: $base-link-color;
+$hover-button-color: $hover-link-color;
+
+// Flash Colors
+$alert-color: $light-yellow;
+$error-color: $light-red;
+$notice-color: lighten($base-accent-color, 40);
+$success-color: $light-green;
+
+// Border color
+$base-border-color: $light-gray;
+$base-border: 1px solid $base-border-color;
+
+// Forms
+$form-border-color: $base-border-color;
+$form-border-color-hover: darken($base-border-color, 10);
+$form-border-color-focus: $base-accent-color;
+$form-border-radius: $base-border-radius;
+$form-box-shadow: inset 0 1px 3px rgba(black,0.06);
+$form-box-shadow-focus: $form-box-shadow, 0 0 5px rgba(darken($form-border-color-focus, 5), 0.7);
+$form-font-size: $base-font-size;
+$form-font-family: $base-font-family;

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$sans-serif: "proxima-nova", "open sans", arial, sans-serif;
+$sans-serif: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
 // $serif: $georgia;
 $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;
@@ -40,7 +40,7 @@ $dark-gray: #323A45; // Text/Rules
 $gray: #777777; // Text 2
 $blue: #0067BA; // Links
 $aqua-blue: #00BFE7; // Graphics
-$blue: #0096B5; //Rollover
+$medium-blue: #0096B5; // Rollover
 $light-blue: #CDEAF0; // Highlight
 $light-gray: #EAEDF1; // Background
 $medium-gray: #CCCCCC; // Rules 2

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -1,6 +1,6 @@
 // Typography
 $sans-serif: "proxima-nova", "open sans", arial, sans-serif;
-$serif: $georgia;
+// $serif: $georgia;
 $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;
 
@@ -31,6 +31,16 @@ $light-red: #FBE3E4;
 $light-yellow: #FFF6BF;
 $light-green: #E6EFC2;
 
+// FOIA Hub Colors
+$dark-gray: #323A45; // Text/Rules
+$gray: #777777; // Text 2
+$blue: #0067BA; // Links
+$aqua-blue: #00BFE7; // Graphics
+$blue: #0096B5; //Rollover
+$light-blue: #CDEAF0; // Highlight
+$light-gray: #EAEDF1; // Background
+$medium-gray: #CCCCCC; // Rules 2
+
 // Background Color
 $base-background-color: white;
 
@@ -51,7 +61,7 @@ $notice-color: lighten($base-accent-color, 40);
 $success-color: $light-green;
 
 // Border color
-$base-border-color: $light-gray;
+$base-border-color: $dark-gray;
 $base-border: 1px solid $base-border-color;
 
 // Forms

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$sans-serif: 'Proxima Nova', sans-serif;
+$sans-serif: "proxima-nova", "open sans", arial, sans-serif;
 $serif: $georgia;
 $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$sans-serif: $helvetica;
+$sans-serif: 'Proxima Nova', sans-serif;
 $serif: $georgia;
 $base-font-family: $sans-serif;
 $header-font-family: $base-font-family;

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -13,6 +13,10 @@ $h4-font-size: $base-font-size * 1.5;
 $h5-font-size: $base-font-size * 1.25;
 $h6-font-size: $base-font-size;
 
+//Font Weights
+$header-font-weight: 600;
+
+
 // Line height
 $base-line-height: 1.5;
 $header-line-height: 1.25;

--- a/foia_hub/static/sass/base/extends/_button.scss
+++ b/foia_hub/static/sass/base/extends/_button.scss
@@ -1,0 +1,22 @@
+%button {
+  -webkit-font-smoothing: antialiased;
+  background-color: $base-button-color;
+  border-radius: $base-border-radius;
+  color: white;
+  display: inline-block;
+  font-size: $base-font-size;
+  font-weight: bold;
+  line-height: 1;
+  padding: 0.75em 1em;
+  text-decoration: none;
+
+  &:hover {
+    background-color: $hover-button-color;
+    color: white;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}

--- a/foia_hub/static/sass/base/extends/_clearfix.scss
+++ b/foia_hub/static/sass/base/extends/_clearfix.scss
@@ -1,0 +1,3 @@
+%clearfix {
+  @include clearfix;
+}

--- a/foia_hub/static/sass/base/extends/_errors.scss
+++ b/foia_hub/static/sass/base/extends/_errors.scss
@@ -1,0 +1,11 @@
+%error {
+  color: darken($error-color, 60);
+}
+
+%warning {
+  color: darken($alert-color, 60);
+}
+
+%notice {
+  color: darken($notice-color, 60);
+}

--- a/foia_hub/static/sass/base/extends/_flashes.scss
+++ b/foia_hub/static/sass/base/extends/_flashes.scss
@@ -1,0 +1,38 @@
+@mixin flash($color) {
+  background: $color;
+  color: darken($color, 60);
+
+  a {
+    color: darken($color, 70);
+
+    &:hover {
+      color: darken($color, 90);
+    }
+  }
+}
+
+%flash-base {
+  font-weight: bold;
+  margin-bottom: $base-spacing / 2;
+  padding: $base-spacing / 2;
+}
+
+%flash-alert {
+  @extend %flash-base;
+  @include flash($alert-color);
+}
+
+%flash-error {
+  @extend %flash-base;
+  @include flash($error-color);
+}
+
+%flash-notice {
+  @extend %flash-base;
+  @include flash($notice-color);
+}
+
+%flash-success {
+  @extend %flash-base;
+  @include flash($success-color);
+}

--- a/foia_hub/static/sass/base/extends/_hide-text.scss
+++ b/foia_hub/static/sass/base/extends/_hide-text.scss
@@ -1,0 +1,3 @@
+%hide-text {
+  @include hide-text;
+}

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -2,6 +2,7 @@
 @import "bourbon/bourbon";
 @import "grid-settings";
 @import "neat/neat";
+@import "base/base";
 
 body {
   padding-bottom: 20px;

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -14,33 +14,29 @@ body > header {
   border-bottom: 1px solid #dedede;
   a:hover {text-decoration: none;}
   h1 {
-    @include span-columns(6);
-
+    float:left;
     font-weight: normal;
     font-size: 2em;
   
-    color: #18f;
-    a {color: #18f;}
+    color: $blue;
+    a { color: $blue; }
     strong {font-weight: 800;}
     em { color: #cc2211; font-style: normal;}
-  }
+  } /* Wordmark */
 
   nav {
-    @include span-columns(10);
-    @include shift(8);
-
     ul {
       li {
         display: inline-block;
-        padding: 9px 12px 0 12px;
+        padding: 9px 10px 0 10px;
       }
 
       a {
         color: #333;
-        padding: 5px 0px 25px 0px;
+        padding: 0 0px 6px 0;
       }
       a:hover, a.active {
-        border-bottom: 0.3em solid #777;
+        border-bottom: 0.3em solid $aqua-blue;
       }
       a:hover {
         background: none;
@@ -95,13 +91,19 @@ body > header {
 }
 
 div#usa {
-  background-color: rgba(0, 0, 0, 0.75);
+  background-color: $dark-gray;
+  color: $light-gray;
   .usa--content {
-    h4 { font-size: 0.75em; font-weight: 500; margin: 0.4em 0;}
     padding-top: 0.75em;
     margin-bottom:0.8em;
-    color: #ddd;
-    text-align:center;
+  }
+  .official { float:left; }
+  .alpha {float:right; }
+  .official, .alpha {
+      @include media($medium) {
+        float:none;
+        text-align: center;
+      }
   }
 }
 
@@ -111,21 +113,24 @@ div#usa {
     padding-top: 20px;
   }
 
-  section.search {
+  .search {
+    background: $dark-gray;
+    color: $light-gray;
+  }
+
+  .search--content {
     @include inner(16);
-    padding: 70px 0;
+//    padding: 70px 0;
 
     h2 {
       text-align: center;
       font-weight: normal;
-      font-size: 28pt;
       margin: 0; padding: 0;
+      border-bottom: none;
     }
 
     p {
       margin-top: 30px;
-      font-size: 18pt;
-      line-height: 36px;
     }
 
     .search-box {
@@ -134,37 +139,35 @@ div#usa {
 
     p.browse {
       margin-top: 15px;
-      font-size: 10pt;
-      line-height: 20px;
       text-align: center;
     }
 
-    hr {
-      margin-top: 80px;
-    }
   }
 
   footer {
     div.left {
-      @include span-columns(3);
+      @include span-columns(2 of 24);
       @include media($medium) {
-        @include span-columns(3);
+        @include span-columns(2);
       }
       @include media($small) {
         @include span-columns(1);
       }
 
       img {
-        width: 100px; height: 100px;
-        margin: 10px 0;
+        width: 100%;
+        height: 100%;
+        // margin: 10px 0;
         vertical-align: top;
       }
     }
 
     div.right {
       @include span-columns(21);
+      @include shift(1);
       @include media($medium) {
         @include span-columns(9 of 12);
+        @include shift(0);
       }
       @include media($small) {
         @include span-columns(3);
@@ -192,22 +195,16 @@ div#usa {
 }
 
 .hero {
-  background-color: #f1f8ff;
+  background-color: $light-gray;
   padding: 2em 0;
-  background-size: contain;
+//  background-size: contain;
 
   & > .container > .hero--content {
     @include inner(16);
-    h2 {
-      text-align: center;
-      font-weight: normal;
-      font-size: 28pt;
-      margin: 0; padding: 0;
-    }
     p {
       /* VZ: This should be moved to a variable. Prob powered by Bitters. */
       margin-top: 30px;
-      font-size: 21pt;
+      font-size: 2em;
       line-height: 40px;
     }
 }

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -463,10 +463,6 @@ form.request {
   }
 }
 
-html, button, input, select, textarea {
-  font-family: 'Open Sans', sans-serif;
-}
-h1,h2,h3,h4,h5,h6 { font-family: 'Raleway', sans-serif; }
 a { color: #18f; text-decoration: none;}
 a:hover {text-decoration: underline}
 p a:hover { text-decoration: underline; }

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -34,15 +34,12 @@ body > header {
       }
 
       a {
-        color: #333;
+        color: $gray;
         padding-bottom:12px;
       }
       a:hover, a.active {
         border-bottom: 0.3em solid $aqua-blue;
-      }
-      a:hover {
-        background: none;
-        color: #777;
+        color: $dark-gray;
       }
       a:focus {
         // background: #cc2211;
@@ -95,17 +92,20 @@ body > header {
 div#usa {
   background-color: $dark-gray;
   color: $light-gray;
+  padding: 0.25em 0;
   .usa--content {
-    padding-top: 0.75em;
-    margin-bottom:0.8em;
+    font-size: 0.8em;
   }
   .official { float:left; }
   .alpha {float:right; }
   .official, .alpha {
-      @include media($medium) {
-        float:none;
-        text-align: center;
-      }
+    display: inline-block;
+    a { color: $aqua-blue;}  
+    @include media($medium) {
+      float:none;
+      display: block;
+      text-align: center;
+    }
   }
 }
 
@@ -118,6 +118,7 @@ div#usa {
   .search {
     background: $dark-gray;
     color: $light-gray;
+    padding: 3.4em 0;
   }
 
   .search--content {
@@ -125,9 +126,6 @@ div#usa {
 //    padding: 70px 0;
 
     h2 {
-      text-align: center;
-      font-weight: normal;
-      margin: 0; padding: 0;
       border-bottom: none;
     }
 
@@ -204,10 +202,14 @@ div#usa {
   & > .container > .hero--content {
     @include inner(16);
     p {
-      /* VZ: This should be moved to a variable. Prob powered by Bitters. */
-      margin-top: 30px;
-      font-size: 2em;
-      line-height: 40px;
+      font-size: $h2-font-size;
+      line-height: $header-line-height;
+      font-weight: $header-font-weight;
+      margin: 1em 0;
+    } // VZ: Maybe create a pseudo-H2 class for this?
+    a.more {
+      font-size: 1em;
+      font-weight: $header-font-weight;
     }
 }
 
@@ -370,11 +372,6 @@ div#usa {
       overflow:hidden;
     }
 
-    h3 {
-      padding: 0; margin: 0;
-      font-weight: bold;
-    }
-
     ul, li {
       list-style-type: none;
       list-style-position: outside;
@@ -404,8 +401,6 @@ div#usa {
 
   .contact_type {
     h3 {
-      font-size: 1.6em;
-      font-weight: normal;
       margin-bottom: 5px;
     }
   }
@@ -416,7 +411,6 @@ div#usa {
     //@include clearfix();
     p {
       font-size: 1em;
-      font-weight: bold;
     }
   }
 

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -29,7 +29,7 @@ body > header {
 #topnav nav {
     ul {
       @include media($small) {
-        @include span-columns(3);
+//        @include span-columns(3);
       }
       li {
         display: inline-block;
@@ -66,10 +66,10 @@ body > header {
 @mixin inner($columns) {
   @include shift( ( 24 - $columns )/ 2 );
   @include span-columns( $columns );
-  @include media($large) {
+/*  @include media($large) {
     @include shift(2);
     @include span-columns(20)
-  }
+  }*/
   @include media($medium) {
     @include shift(1);
     @include span-columns(10);
@@ -104,6 +104,7 @@ div#usa {
   padding: 0.25em 0;
   .usa--content {
     font-size: 0.8em;
+    font-weight: 800;
   }
   .official { float:left; }
   .alpha {float:right; }

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -13,27 +13,29 @@ body {
 body > header {
   border-bottom: 1px solid #dedede;
   a:hover {text-decoration: none;}
-  h1 {
+  #topnav {
+    margin: 1em 0 0.8em;
+  }
+  #logo {
     float:left;
-    font-weight: normal;
-    font-size: 2em;
-  
+    // font-weight: normal;
+    // font-size: 2em;
     color: $blue;
     a { color: $blue; }
     strong {font-weight: 800;}
     em { color: #cc2211; font-style: normal;}
-  } /* Wordmark */
+  }
 
   nav {
     ul {
       li {
         display: inline-block;
-        padding: 9px 10px 0 10px;
+        padding: 0 10px 0 10px;
       }
 
       a {
         color: #333;
-        padding: 0 0px 6px 0;
+        padding-bottom:12px;
       }
       a:hover, a.active {
         border-bottom: 0.3em solid $aqua-blue;
@@ -129,8 +131,9 @@ div#usa {
       border-bottom: none;
     }
 
-    p {
-      margin-top: 30px;
+    a {
+      color: $aqua-blue;
+      font-weight: 800;
     }
 
     .search-box {
@@ -138,8 +141,7 @@ div#usa {
     }
 
     p.browse {
-      margin-top: 15px;
-      text-align: center;
+//      margin-top: 15px;
     }
 
   }

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -1,15 +1,14 @@
 @import "normalize";
-@import "bourbon/bourbon";
-@import "grid-settings";
-@import "neat/neat";
+@import "bourbon";
+// @import "grid-settings";
+@import "base/grid-settings";
 @import "base/base";
+@import "neat";
+
 
 body {
   padding-bottom: 20px;
 }
-
-/* a couple things that stand outside the normal hierarchy, because
-   they extend the full width, beyond the normal outer-container */
 
 body > header {
   border-bottom: 1px solid #dedede;
@@ -63,7 +62,14 @@ body > header {
 @mixin inner($columns) {
   @include shift( ( 24 - $columns )/ 2 );
   @include span-columns( $columns );
-
+  @include media($large) {
+    @include shift(2);
+    @include span-columns(20)
+  }
+  @include media($medium) {
+    @include shift(1);
+    @include span-columns(10);
+  }
   @include media($small) {
     @include shift(0);
     @include span-columns(4);

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -26,20 +26,29 @@ body > header {
     em { color: #cc2211; font-style: normal;}
   }
 
-  nav {
+#topnav nav {
     ul {
+      @include media($small) {
+        @include span-columns(3);
+      }
       li {
         display: inline-block;
-        padding: 0 10px 0 10px;
+        padding: 0 10px;
       }
 
       a {
         color: $gray;
         padding-bottom:12px;
+        @include media($small) {
+            padding-bottom: 0;
+          }
       }
       a:hover, a.active {
         border-bottom: 0.3em solid $aqua-blue;
         color: $dark-gray;
+        @include media($small) {
+          border-bottom: 1px solid $aqua-blue;
+        }
       }
       a:focus {
         // background: #cc2211;
@@ -110,7 +119,6 @@ div#usa {
 }
 
 #main {
-  /* /about and /learn */
   .content {
     padding-top: 20px;
   }
@@ -134,21 +142,17 @@ div#usa {
       font-weight: 800;
     }
 
-    .search-box {
-      margin-top: 30px;
+    .search--box {
+      margin: 30px 0;
     }
-
-    p.browse {
-//      margin-top: 15px;
-    }
-
   }
 
   footer {
+    margin-top: 1em;
     div.left {
-      @include span-columns(2 of 24);
+      @include span-columns(2);
       @include media($medium) {
-        @include span-columns(2);
+        @include span-columns(1);
       }
       @include media($small) {
         @include span-columns(1);
@@ -157,8 +161,6 @@ div#usa {
       img {
         width: 100%;
         height: 100%;
-        // margin: 10px 0;
-        vertical-align: top;
       }
     }
 
@@ -197,11 +199,12 @@ div#usa {
 .hero {
   background-color: $light-gray;
   padding: 2em 0;
+
 //  background-size: contain;
 
   & > .container > .hero--content {
     @include inner(16);
-    p {
+    p.big {
       font-size: $h2-font-size;
       line-height: $header-line-height;
       font-weight: $header-font-weight;
@@ -223,23 +226,7 @@ div#usa {
 
 #main.home {
   section.process {
-
-    ul {
-      margin-top: 30px;
-
-      figure {
-        @include span-columns(6);
-
-        padding: 0; margin: 0;
-        padding: 10px;
-
-        img {width: 100%;}
-        figcaption {
-          font-size: 11pt;
-          line-height: 24px;
-        }
-      }
-    }
+    ol { @extend %default-ol; }
   }
 }
 
@@ -456,12 +443,25 @@ form.request {
   }
 }
 
-a { color: #18f; text-decoration: none;}
 a:hover {text-decoration: underline}
 p a:hover { text-decoration: underline; }
 
 
-input.search, input.agency { width: 100% }
+input.agency { width: 100% }
+
+.search input {
+  color: $dark-gray;
+  width: 100%;
+  background-color: white;
+  display:inline-block;
+}
+.search button {
+  background-color: $aqua-blue;
+  color: $dark-gray;
+  display:inline-block;
+  width: 5%;
+  min-width: 6em;
+}
 
 .pure-menu .pure-menu-selected a { border-bottom: 0.3em solid #333;}
 
@@ -541,6 +541,7 @@ div.request.error {
 }
 
 .tt-suggestion {
+  color: $dark-gray;
   padding: 8px 20px;
   font-size: 18px;
   line-height: 24px;

--- a/foia_hub/templates/contacts/contact.html
+++ b/foia_hub/templates/contacts/contact.html
@@ -1,4 +1,4 @@
-
+ 
 {% if profile.foia_libraries %}
     <div class="reading_room resource_type">
         <div class="icon">

--- a/foia_hub/templates/includes/head.html
+++ b/foia_hub/templates/includes/head.html
@@ -5,7 +5,6 @@
 <!-- TODO: cache-bust main.css -->
 <link rel="stylesheet" href="/static/css/main.css" />
 <link rel="stylesheet" href="/static/font-awesome-4.2.0/css/font-awesome.min.css" />
-<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,400,700,300|Raleway:400,300,700,600' rel='stylesheet' />
 
 <script src="/static/js/jquery-2.1.1.min.js"></script>
 <!-- TODO: cache-bust -->

--- a/foia_hub/templates/includes/head.html
+++ b/foia_hub/templates/includes/head.html
@@ -22,3 +22,7 @@
 <!--[if gt IE 8]><!-->
     <link rel="stylesheet" href="/static/css/grids-responsive-min.css">
 <!--<![endif]-->
+
+<!--TypeKit for Proxima Nova -->
+<script src="//use.typekit.net/tbd8pdb.js"></script>
+<script>try{Typekit.load();}catch(e){}</script>

--- a/foia_hub/templates/includes/nav.html
+++ b/foia_hub/templates/includes/nav.html
@@ -2,8 +2,8 @@
   <div id="usa">
     <div class="container">
       <div class="usa--content">
-        <h6 class="official"><img alt="US flag signifying that this is a United States Federal Government website" src="/static/images/us_flag_small.png"> An official website of the U.S. Government</h6>
-        <h6 class="alpha">This website is in alpha. <a href="/about">Help us improve <i class="fa fa-arrow-right"></i></a></h6>
+        <span class="official"><img alt="US flag signifying that this is a United States Federal Government website" src="/static/images/us_flag_small.png" class="flag">&nbsp;&nbsp;An official website of the U.S. Government</span>
+        <span class="alpha">This website is in alpha. <a href="/about">Help us improve <i class="fa fa-arrow-right"></i></a></span>
       </div>
     </div>
   </div>

--- a/foia_hub/templates/includes/nav.html
+++ b/foia_hub/templates/includes/nav.html
@@ -2,8 +2,8 @@
   <div id="usa">
     <div class="container">
       <div class="usa--content">
-        <h4 class="official">An official website of the United States Government <img alt="US flag signifying that this is a United States Federal Government website" src="/static/images/us_flag_small.png"></h4>
-        <h4>This site is in alpha. <a href="http://github.com/18f/foia-hub">Learn more.</a></h4>
+        <h6 class="official"><img alt="US flag signifying that this is a United States Federal Government website" src="/static/images/us_flag_small.png"> An official website of the U.S. Government</h6>
+        <h6 class="alpha">This website is in alpha. <a href="/about">Help us improve <i class="fa fa-arrow-right"></i></a></h6>
       </div>
     </div>
   </div>

--- a/foia_hub/templates/includes/nav.html
+++ b/foia_hub/templates/includes/nav.html
@@ -7,24 +7,26 @@
       </div>
     </div>
   </div>
-  <div class="container">
-    <h1 id="logo">
-      <a href="/">
-        FOIA<em><strong>Hub</strong></em>
-      </a>
-    </h1>
+  <div id="topnav">
+    <div class="container">
+      <div id="logo">
+        <a href="/">
+          FOIA<em><strong>HUB</strong></em>
+        </a>
+      </div>
 
-    <nav>
-      <ul>
-        <li><a
-            {% if request and ('/learn/' == request.path) %}class="active"{% endif %}
-            href="/learn/">Understanding FOIA
+      <nav>
+        <ul>
+          <li><a
+              {% if request and ('/learn/' == request.path) %}class="active"{% endif %}
+              href="/learn/">Understanding FOIA
+            </a></li>
+          <li><a
+            {% if request and ('/about/' == request.path) %}class="active"{% endif %}
+            href="/about/">About this Project
           </a></li>
-        <li><a
-          {% if request and ('/about/' == request.path) %}class="active"{% endif %}
-          href="/about/">About this Project
-        </a></li>
-      </ul>
-    </nav>
+        </ul>
+      </nav>
+    </div>
   </div>
 </header>

--- a/foia_hub/templates/includes/search.html
+++ b/foia_hub/templates/includes/search.html
@@ -1,31 +1,26 @@
-<div class="container">
-  <section class="search">
-    <h2>
-      Which agency do you want to contact?
-    </h2>
+<div class="search">
+  <div class="container">
+    <section class="search--content">
+      <h2>Want to make a FOIA request?</h2>
 
-    <p>
-      Each U.S. federal agency processes its own requests. Contact the agency that is directly responsible for the information that you seek.
-    </p>
+      <form class="agency" method="get" action="/agencies/">
+        <div class="search-box scrollable-dropdown-menu">
+          <input class="typeahead agency" name="query" type="search"
+            {% if query %}
+              value="{{ query }}"
+            {% endif %}
+            />
+        </div>
+      </form>
 
-    <form class="agency" method="get" action="/agencies/">
-      <div class="search-box scrollable-dropdown-menu">
-        <input class="typeahead agency" name="query" type="search"
-          {% if query %}
-            value="{{ query }}"
-          {% endif %}
-          />
-      </div>
-    </form>
+      <p class="browse">
+        <a href="/agencies/">Or browse a list of federal agencies</a>
+      </p>
 
-    <p class="browse">
-      <a href="/agencies/">or browse a list of federal agencies</a>
-    </p>
-
-    <hr />
-  </section>
+      <hr />
+    </section>
+  </div>
 </div>
-
 
 <script src="/static/js/typeahead.bundle.js"></script>
 <script src="/static/js/handlebars-v1.2.0.js"></script>

--- a/foia_hub/templates/includes/search.html
+++ b/foia_hub/templates/includes/search.html
@@ -14,10 +14,9 @@
       </form>
 
       <p class="browse">
-        <a href="/agencies/">Or browse a list of federal agencies</a>
+        <a href="/agencies/">Or browse a list of federal agencies <i class="fa fa-arrow-right"></i></a>
       </p>
 
-      <hr />
     </section>
   </div>
 </div>

--- a/foia_hub/templates/includes/search.html
+++ b/foia_hub/templates/includes/search.html
@@ -13,9 +13,9 @@
         </div>
       </form>
 
-      <p class="browse">
+      <span class="browse">
         <a href="/agencies/">Or browse a list of federal agencies <i class="fa fa-arrow-right"></i></a>
-      </p>
+      </span>
 
     </section>
   </div>

--- a/foia_hub/templates/includes/search.html
+++ b/foia_hub/templates/includes/search.html
@@ -4,12 +4,15 @@
       <h2>Want to make a FOIA request?</h2>
 
       <form class="agency" method="get" action="/agencies/">
-        <div class="search-box scrollable-dropdown-menu">
-          <input class="typeahead agency" name="query" type="search"
-            {% if query %}
-              value="{{ query }}"
-            {% endif %}
-            />
+        <div class="search--box scrollable-dropdown-menu">
+          <form id="search">
+            <input class="typeahead agency" name="query" type="search" placeholder="Search for a topic or the agency you want to contact"
+              {% if query %}
+                value="{{ query }}"
+              {% endif %}
+              />
+<!--            <button form="search" type="submit" name="submit">Search</button>-->
+          </form>
         </div>
       </form>
 

--- a/foia_hub/templates/index.html
+++ b/foia_hub/templates/index.html
@@ -10,7 +10,7 @@
         <section class="hero--content">
             <h2>What is FOIA?</h2>
             <p>The Freedom of Information Act, or FOIA, provides you the right to request access to government records. Under FOIA, government agencies are required to disclose any information requested unless it falls under a specific set of exemptions or exclusions.</p>
-			<p><a class="more" href="/learn/">Learn more about FOIA <i class="fa fa-arrow-right"></i></a></p>
+			<a class="more" href="/learn/">Learn more about FOIA <i class="fa fa-arrow-right"></i></a>
 
 			<hr>
 

--- a/foia_hub/templates/index.html
+++ b/foia_hub/templates/index.html
@@ -10,7 +10,7 @@
         <section class="hero--content">
             <h2>What is FOIA?</h2>
             <p>The Freedom of Information Act, or FOIA, provides you the right to request access to government records. Under FOIA, government agencies are required to disclose any information requested unless it falls under a specific set of exemptions or exclusions.</p>
-			<p><a class="more" href="/learn/">Learn more about FOIA.</a></p>
+			<p><a class="more" href="/learn/">Learn more about FOIA <i class="fa fa-arrow-right"></i></a></p>
 
 			<hr>
 

--- a/foia_hub/templates/index.html
+++ b/foia_hub/templates/index.html
@@ -3,18 +3,26 @@
 
 {% block body %}
 
+{% include "includes/search.html" %}
+
 <div class="hero">
     <div class="container">
         <section class="hero--content">
             <h2>What is FOIA?</h2>
-            <p>
-                The Freedom of Information Act (FOIA) provides you the right to request access to government records. Under FOIA, government agencies are <strong><em>required</em></strong> to disclose any records requested, unless they fall under a specific set of exemptions or exclusions.
-                <a class="more" href="/learn/">Learn more about FOIA.</a>
-            </p>
+            <p>The Freedom of Information Act, or FOIA, provides you the right to request access to government records. Under FOIA, government agencies are required to disclose any information requested unless it falls under a specific set of exemptions or exclusions.</p>
+			<p><a class="more" href="/learn/">Learn more about FOIA.</a></p>
+
+			<hr>
+
+			<h2>How does the process work?</h2>
+			<ol>
+				<li>Submit a FOIA request directly to the agency you believe holds the information you seek.</li>
+				<li>The FOIA officials at that agency will (usually) email receipt of your request and begin looking for the requested records or point you to a public space where the records may already be accessed.</li>
+				<li>As the records are collected, they will be assessed to determine what can be provided to the requestor.</li>
+				<li>FOIA officials at the agency send the requester their "determination. The records may be in full, partial or redacted or denied as a request.</li>
+			</ol>
         </section>
     </div>
 </div>
-
-{% include "includes/search.html" %}
 
 {% endblock %}

--- a/foia_hub/templates/index.html
+++ b/foia_hub/templates/index.html
@@ -8,19 +8,25 @@
 <div class="hero">
     <div class="container">
         <section class="hero--content">
-            <h2>What is FOIA?</h2>
+	        <h2><em>FOIA Hub is the first front door to the  United States Freedom of Information Act request process that includes current contact information for every federal agency.</em></h2>
+	        
+	        <hr>
+            
+            <h2><em>What is FOIA?</em></h2>
             <p>The Freedom of Information Act, or FOIA, provides you the right to request access to government records. Under FOIA, government agencies are required to disclose any information requested unless it falls under a specific set of exemptions or exclusions.</p>
 			<a class="more" href="/learn/">Learn more about FOIA <i class="fa fa-arrow-right"></i></a>
 
 			<hr>
 
-			<h2>How does the process work?</h2>
-			<ol>
-				<li>Submit a FOIA request directly to the agency you believe holds the information you seek.</li>
-				<li>The FOIA officials at that agency will (usually) email receipt of your request and begin looking for the requested records or point you to a public space where the records may already be accessed.</li>
-				<li>As the records are collected, they will be assessed to determine what can be provided to the requestor.</li>
-				<li>FOIA officials at the agency send the requester their "determination. The records may be in full, partial or redacted or denied as a request.</li>
-			</ol>
+			<section class="process">
+				<h2><em>How does the process work?</em></h2>
+				<ol class="default">
+					<li>Submit a FOIA request directly to the agency you believe holds the information you seek.</li>
+					<li>The FOIA officials at that agency will (usually) email receipt of your request and begin looking for the requested records or point you to a public space where the records may already be accessed.</li>
+					<li>As the records are collected, they will be assessed to determine what can be provided to the requestor.</li>
+					<li>FOIA officials at the agency send the requester their "determination. The records may be in full, partial or redacted or denied as a request.</li>
+				</ol>
+			</section>
         </section>
     </div>
 </div>


### PR DESCRIPTION
# Redesign

This pull request implements the sitewide elements including alpha+US Gov banner, top nav, footer, new typography and colors throughout, a new header em style for underlined headers, and Bourbon Bitters for styling.

# Views

## Homepage Large
![screen shot 2015-01-20 at 9 04 32 am](https://cloud.githubusercontent.com/assets/582918/5818811/9b7f422c-a086-11e4-8c2c-546e07c427f2.png)

## Homepage Medium
![screen shot 2015-01-20 at 9 24 36 am](https://cloud.githubusercontent.com/assets/582918/5818812/9e340aa2-a086-11e4-8208-9b052d7407ee.png)

## Homepage Small
![screen shot 2015-01-20 at 9 24 45 am](https://cloud.githubusercontent.com/assets/582918/5818817/a48d697a-a086-11e4-9d54-f1b356a9bd2d.png)

# Notes

This uses a TypeKit version of Proxima Nova, the main typeface for FOIAHub. We should move the font hosting to 18F servers for the final product. IE support is not implemented yet.