### PR TITLE
Redesign: Agency landing page implementation, search results page

### DIFF
--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -938,7 +938,7 @@ div#usa {
   font-size: 1.6em; }
 #main.landing .department h3 {
   font-size: 1.05em; }
-#main.landing .department hr {
+#main.landing .department .details > hr {
   border-bottom: 1px solid #323A45; }
 #main.landing .department .resources {
   float: left;
@@ -947,7 +947,8 @@ div#usa {
   width: 36.8421052632%;
   margin-left: 4.2105263158%;
   padding: 1em;
-  background-color: white; }
+  background-color: white;
+  box-shadow: 4px 4px 8px #CCC; }
   #main.landing .department .resources:last-child {
     margin-right: 0; }
   @media screen and (max-width: 48em) {
@@ -1000,8 +1001,8 @@ div#usa {
   font-size: 1em; }
 #main.landing .department .contact_type h3 {
   margin-bottom: 5px; }
-#main.landing .inaccurate p {
-  font-size: 1em; }
+#main.landing .inaccurate {
+  clear: both; }
 
 form.request input.upto[type=text] {
   width: 80px;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -406,19 +406,19 @@ h6 {
 .hero--content h1, .hero--content h2, .hero--content h3, .hero--content h4, .hero--content h5, .hero--content h6 {
   padding-bottom: 0.8em; }
 
-h1 {
-  font-size: 2.25em; }
-
-h2 {
-  font-size: 2em; }
-
 h1 em, h2 em, h3 em, h4 em, h5 em, h6 em {
   border-bottom: 0.15em solid #00BFE7;
   line-height: 1.5625;
   font-style: normal; }
 
+h1 {
+  font-size: 2.25em; }
+
+h2 {
+  font-size: 1.5em; }
+
 h3 {
-  font-size: 1.75em; }
+  font-size: 1.125em; }
 
 h4 {
   font-size: 1.5em; }
@@ -662,7 +662,7 @@ div#usa {
   padding: 0.25em 0; }
   div#usa .usa--content {
     font-size: 0.8em;
-    font-weight: 800; }
+    font-weight: 700; }
   div#usa .official {
     float: left; }
   div#usa .alpha {
@@ -677,61 +677,58 @@ div#usa {
         display: block;
         text-align: center; } }
 
-#main {
-  min-height: 99%;
-  position: relative; }
-  #main .search {
-    background: #323A45;
-    color: #EAEDF1;
-    padding: 3.4em 0; }
-  #main .search--content {
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 66.3157894737%;
-    margin-left: 16.8421052632%;
-    /*  @include media($large) {
-        @include shift(2);
-        @include span-columns(20)
-      }*/ }
-    #main .search--content:last-child {
-      margin-right: 0; }
-    @media screen and (max-width: 48em) {
-      #main .search--content {
-        margin-left: 4.2105263158%;
-        float: left;
-        display: block;
-        margin-right: 2.1276595745%;
-        width: 82.9787234043%; }
-        #main .search--content:last-child {
-          margin-right: 0; } }
-    @media screen and (max-width: 30em) {
-      #main .search--content {
-        margin-left: 0%;
-        float: left;
-        display: block;
-        margin-right: 6.6666666667%;
-        width: 100%; }
-        #main .search--content:last-child {
-          margin-right: 0; } }
-    #main .search--content h2 {
-      border-bottom: none; }
-    #main .search--content a {
-      color: #00BFE7;
-      font-weight: 800; }
-    #main .search--content .search--box {
-      margin: 30px 0; }
-  #main footer {
-    background-color: white;
-    padding-top: 1em; }
-    #main footer div.left {
+#main .search {
+  background: #323A45;
+  color: #EAEDF1;
+  padding: 3.4em 0; }
+#main .search--content {
+  float: left;
+  display: block;
+  margin-right: 1.0526315789%;
+  width: 66.3157894737%;
+  margin-left: 16.8421052632%;
+  /*  @include media($large) {
+      @include shift(2);
+      @include span-columns(20)
+    }*/ }
+  #main .search--content:last-child {
+    margin-right: 0; }
+  @media screen and (max-width: 48em) {
+    #main .search--content {
+      margin-left: 4.2105263158%;
       float: left;
-      padding-right: 1em; }
-      #main footer div.left img {
-        width: 32px;
-        height: 32px; }
-    #main footer div.right {
-      float: left; }
+      display: block;
+      margin-right: 2.1276595745%;
+      width: 82.9787234043%; }
+      #main .search--content:last-child {
+        margin-right: 0; } }
+  @media screen and (max-width: 30em) {
+    #main .search--content {
+      margin-left: 0%;
+      float: left;
+      display: block;
+      margin-right: 6.6666666667%;
+      width: 100%; }
+      #main .search--content:last-child {
+        margin-right: 0; } }
+  #main .search--content h2 {
+    border-bottom: none; }
+  #main .search--content a {
+    color: #00BFE7;
+    font-weight: 800; }
+  #main .search--content .search--box {
+    margin: 30px 0; }
+#main footer {
+  background-color: white;
+  padding-top: 1em; }
+  #main footer div.left {
+    float: left;
+    padding-right: 1em; }
+    #main footer div.left img {
+      width: 32px;
+      height: 32px; }
+  #main footer div.right {
+    float: left; }
 
 .container {
   max-width: 68em;
@@ -794,7 +791,7 @@ div#usa {
         .hero > .container > .hero--content:last-child {
           margin-right: 0; } }
     .hero > .container > .hero--content p.big {
-      font-size: 2em;
+      font-size: 1.5em;
       line-height: 1.25;
       font-weight: 600;
       margin: 1em 0; }
@@ -809,13 +806,36 @@ div#usa {
   color: #00BFE7; }
 
 .content {
+  margin-left: 106.6666666667%;
   float: left;
   display: block;
   margin-right: 1.0526315789%;
   width: 66.3157894737%;
-  margin-left: 16.8421052632%; }
+  margin-left: 16.8421052632%;
+  /*  @include media($large) {
+      @include shift(2);
+      @include span-columns(20)
+    }*/ }
   .content:last-child {
     margin-right: 0; }
+  @media screen and (max-width: 48em) {
+    .content {
+      margin-left: 4.2105263158%;
+      float: left;
+      display: block;
+      margin-right: 2.1276595745%;
+      width: 82.9787234043%; }
+      .content:last-child {
+        margin-right: 0; } }
+  @media screen and (max-width: 30em) {
+    .content {
+      margin-left: 0%;
+      float: left;
+      display: block;
+      margin-right: 6.6666666667%;
+      width: 100%; }
+      .content:last-child {
+        margin-right: 0; } }
 
 .searchresults {
   float: left;
@@ -851,7 +871,7 @@ div#usa {
     font-size: 1.8em;
     padding: 1em 0; }
   .searchresults h2 {
-    font-size: 1.2em; }
+    font-size: 0.9em; }
   .searchresults li {
     padding: 0.5em 0; }
 
@@ -882,9 +902,9 @@ div#usa {
       #main.landing .department .department--container:last-child {
         margin-right: 0; } }
 #main.landing .department h2 {
-  font-size: 1.6em; }
+  font-size: 1.2em; }
 #main.landing .department h3 {
-  font-size: 1.05em; }
+  font-size: 0.675em; }
 #main.landing .department .details > hr {
   border-bottom: 1px solid #323A45; }
 #main.landing .department .resources {

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -902,6 +902,15 @@ div#usa {
 .fa {
   color: #00BFE7; }
 
+.learn, .about {
+  float: left;
+  display: block;
+  margin-right: 1.0526315789%;
+  width: 66.3157894737%;
+  margin-left: 16.8421052632%; }
+  .learn:last-child, .about:last-child {
+    margin-right: 0; }
+
 #main.landing .contact h3 {
   margin-top: 30px;
   margin-bottom: 10px; }

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -384,7 +384,7 @@ input[type="submit"] {
 
 body {
   -webkit-font-smoothing: antialiased;
-  background-color: white;
+  background-color: #EAEDF1;
   color: #323A45;
   font-family: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
   font-size: 1em;
@@ -608,10 +608,8 @@ html {
   -moz-box-sizing: inherit;
   box-sizing: inherit; }
 
-body {
-  padding-bottom: 20px; }
-
 body > header {
+  background-color: white;
   border-bottom: 1px solid #dedede; }
   body > header a:hover {
     text-decoration: none; }
@@ -723,7 +721,8 @@ div#usa {
   #main .search--content .search--box {
     margin: 30px 0; }
 #main footer {
-  margin-top: 1em; }
+  background-color: white;
+  padding-top: 1em; }
   #main footer div.left {
     float: left;
     display: block;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -677,8 +677,6 @@ div#usa {
         display: block;
         text-align: center; } }
 
-#main .content {
-  padding-top: 20px; }
 #main .search {
   background: #323A45;
   color: #EAEDF1;
@@ -923,7 +921,7 @@ div#usa {
   float: left;
   display: block;
   margin-right: 1.0526315789%;
-  width: 57.8947368421%; }
+  width: 62.1052631579%; }
   #main.landing .department .department--container:last-child {
     margin-right: 0; }
   @media screen and (max-width: 48em) {
@@ -944,7 +942,7 @@ div#usa {
   float: left;
   display: block;
   margin-right: 1.0526315789%;
-  width: 36.8421052632%;
+  width: 32.6315789474%;
   margin-left: 4.2105263158%;
   padding: 1em;
   background-color: white;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -726,55 +726,12 @@ div#usa {
     padding-top: 1em; }
     #main footer div.left {
       float: left;
-      display: block;
-      margin-right: 1.0526315789%;
-      width: 7.3684210526%; }
-      #main footer div.left:last-child {
-        margin-right: 0; }
-      @media screen and (max-width: 48em) {
-        #main footer div.left {
-          float: left;
-          display: block;
-          margin-right: 2.1276595745%;
-          width: 6.3829787234%; }
-          #main footer div.left:last-child {
-            margin-right: 0; } }
-      @media screen and (max-width: 30em) {
-        #main footer div.left {
-          float: left;
-          display: block;
-          margin-right: 6.6666666667%;
-          width: 20%; }
-          #main footer div.left:last-child {
-            margin-right: 0; } }
+      padding-right: 1em; }
       #main footer div.left img {
-        width: 100%;
-        height: 100%; }
+        width: 32px;
+        height: 32px; }
     #main footer div.right {
-      float: left;
-      display: block;
-      margin-right: 1.0526315789%;
-      width: 87.3684210526%;
-      margin-left: 4.2105263158%; }
-      #main footer div.right:last-child {
-        margin-right: 0; }
-      @media screen and (max-width: 48em) {
-        #main footer div.right {
-          float: left;
-          display: block;
-          margin-right: 2.1276595745%;
-          width: 74.4680851064%;
-          margin-left: 0%; }
-          #main footer div.right:last-child {
-            margin-right: 0; } }
-      @media screen and (max-width: 30em) {
-        #main footer div.right {
-          float: left;
-          display: block;
-          margin-right: 6.6666666667%;
-          width: 73.3333333333%; }
-          #main footer div.right:last-child {
-            margin-right: 0; } }
+      float: left; }
 
 .container {
   max-width: 68em;
@@ -892,11 +849,14 @@ div#usa {
         margin-right: 0; } }
   .searchresults h1 {
     font-size: 1.8em;
-    padding-top: 1em; }
+    padding: 1em 0; }
   .searchresults h2 {
     font-size: 1.2em; }
   .searchresults li {
     padding: 0.5em 0; }
+
+.breadcrumbs {
+  margin: 1em 0; }
 
 #main.landing .contact h3 {
   margin-top: 30px;
@@ -906,13 +866,6 @@ div#usa {
   list-style-position: outside;
   padding: 0;
   margin: 0; }
-#main.landing .header {
-  margin: 1em 0; }
-  #main.landing .header h1 {
-    margin: 0;
-    padding: 0;
-    margin-top: 10px;
-    font-size: 2.4em; }
 #main.landing .department .department--container {
   float: left;
   display: block;
@@ -998,6 +951,37 @@ div#usa {
 #main.landing .inaccurate {
   clear: both;
   padding-bottom: 2em; }
+
+.department__decentralized {
+  float: left;
+  display: block;
+  margin-right: 1.0526315789%;
+  width: 66.3157894737%;
+  margin-left: 16.8421052632%;
+  /*  @include media($large) {
+      @include shift(2);
+      @include span-columns(20)
+    }*/ }
+  .department__decentralized:last-child {
+    margin-right: 0; }
+  @media screen and (max-width: 48em) {
+    .department__decentralized {
+      margin-left: 4.2105263158%;
+      float: left;
+      display: block;
+      margin-right: 2.1276595745%;
+      width: 82.9787234043%; }
+      .department__decentralized:last-child {
+        margin-right: 0; } }
+  @media screen and (max-width: 30em) {
+    .department__decentralized {
+      margin-left: 0%;
+      float: left;
+      display: block;
+      margin-right: 6.6666666667%;
+      width: 100%; }
+      .department__decentralized:last-child {
+        margin-right: 0; } }
 
 form.request input.upto[type=text] {
   width: 80px;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -634,11 +634,11 @@ body > header {
     @media screen and (max-width: 30em) {
       body > header #topnav nav ul a {
         padding-bottom: 0; } }
-  body > header #topnav nav ul a:hover, body > header #topnav nav ul a.active {
+  body > header #topnav nav ul a:hover, body > header #topnav nav ul a.active, body > header #topnav nav ul #logo:hover {
     border-bottom: 0.3em solid #00BFE7;
     color: #323A45; }
     @media screen and (max-width: 30em) {
-      body > header #topnav nav ul a:hover, body > header #topnav nav ul a.active {
+      body > header #topnav nav ul a:hover, body > header #topnav nav ul a.active, body > header #topnav nav ul #logo:hover {
         border-bottom: 1px solid #00BFE7; } }
   body > header #topnav nav ul a:focus {
     background: #fff;
@@ -677,101 +677,104 @@ div#usa {
         display: block;
         text-align: center; } }
 
-#main .search {
-  background: #323A45;
-  color: #EAEDF1;
-  padding: 3.4em 0; }
-#main .search--content {
-  margin-left: 16.8421052632%;
-  float: left;
-  display: block;
-  margin-right: 1.0526315789%;
-  width: 66.3157894737%;
-  /*  @include media($large) {
-      @include shift(2);
-      @include span-columns(20)
-    }*/ }
-  #main .search--content:last-child {
-    margin-right: 0; }
-  @media screen and (max-width: 48em) {
-    #main .search--content {
-      margin-left: 4.2105263158%;
-      float: left;
-      display: block;
-      margin-right: 2.1276595745%;
-      width: 82.9787234043%; }
-      #main .search--content:last-child {
-        margin-right: 0; } }
-  @media screen and (max-width: 30em) {
-    #main .search--content {
-      margin-left: 0%;
-      float: left;
-      display: block;
-      margin-right: 6.6666666667%;
-      width: 100%; }
-      #main .search--content:last-child {
-        margin-right: 0; } }
-  #main .search--content h2 {
-    border-bottom: none; }
-  #main .search--content a {
-    color: #00BFE7;
-    font-weight: 800; }
-  #main .search--content .search--box {
-    margin: 30px 0; }
-#main footer {
-  background-color: white;
-  padding-top: 1em; }
-  #main footer div.left {
+#main {
+  min-height: 99%;
+  position: relative; }
+  #main .search {
+    background: #323A45;
+    color: #EAEDF1;
+    padding: 3.4em 0; }
+  #main .search--content {
     float: left;
     display: block;
     margin-right: 1.0526315789%;
-    width: 7.3684210526%; }
-    #main footer div.left:last-child {
+    width: 66.3157894737%;
+    margin-left: 16.8421052632%;
+    /*  @include media($large) {
+        @include shift(2);
+        @include span-columns(20)
+      }*/ }
+    #main .search--content:last-child {
       margin-right: 0; }
     @media screen and (max-width: 48em) {
-      #main footer div.left {
+      #main .search--content {
+        margin-left: 4.2105263158%;
         float: left;
         display: block;
         margin-right: 2.1276595745%;
-        width: 6.3829787234%; }
-        #main footer div.left:last-child {
+        width: 82.9787234043%; }
+        #main .search--content:last-child {
           margin-right: 0; } }
     @media screen and (max-width: 30em) {
-      #main footer div.left {
+      #main .search--content {
+        margin-left: 0%;
         float: left;
         display: block;
         margin-right: 6.6666666667%;
-        width: 20%; }
-        #main footer div.left:last-child {
+        width: 100%; }
+        #main .search--content:last-child {
           margin-right: 0; } }
-    #main footer div.left img {
-      width: 100%;
-      height: 100%; }
-  #main footer div.right {
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 87.3684210526%;
-    margin-left: 4.2105263158%; }
-    #main footer div.right:last-child {
-      margin-right: 0; }
-    @media screen and (max-width: 48em) {
-      #main footer div.right {
-        float: left;
-        display: block;
-        margin-right: 2.1276595745%;
-        width: 74.4680851064%;
-        margin-left: 0%; }
-        #main footer div.right:last-child {
-          margin-right: 0; } }
-    @media screen and (max-width: 30em) {
-      #main footer div.right {
-        float: left;
-        display: block;
-        margin-right: 6.6666666667%;
-        width: 73.3333333333%; }
-        #main footer div.right:last-child {
-          margin-right: 0; } }
+    #main .search--content h2 {
+      border-bottom: none; }
+    #main .search--content a {
+      color: #00BFE7;
+      font-weight: 800; }
+    #main .search--content .search--box {
+      margin: 30px 0; }
+  #main footer {
+    background-color: white;
+    padding-top: 1em; }
+    #main footer div.left {
+      float: left;
+      display: block;
+      margin-right: 1.0526315789%;
+      width: 7.3684210526%; }
+      #main footer div.left:last-child {
+        margin-right: 0; }
+      @media screen and (max-width: 48em) {
+        #main footer div.left {
+          float: left;
+          display: block;
+          margin-right: 2.1276595745%;
+          width: 6.3829787234%; }
+          #main footer div.left:last-child {
+            margin-right: 0; } }
+      @media screen and (max-width: 30em) {
+        #main footer div.left {
+          float: left;
+          display: block;
+          margin-right: 6.6666666667%;
+          width: 20%; }
+          #main footer div.left:last-child {
+            margin-right: 0; } }
+      #main footer div.left img {
+        width: 100%;
+        height: 100%; }
+    #main footer div.right {
+      float: left;
+      display: block;
+      margin-right: 1.0526315789%;
+      width: 87.3684210526%;
+      margin-left: 4.2105263158%; }
+      #main footer div.right:last-child {
+        margin-right: 0; }
+      @media screen and (max-width: 48em) {
+        #main footer div.right {
+          float: left;
+          display: block;
+          margin-right: 2.1276595745%;
+          width: 74.4680851064%;
+          margin-left: 0%; }
+          #main footer div.right:last-child {
+            margin-right: 0; } }
+      @media screen and (max-width: 30em) {
+        #main footer div.right {
+          float: left;
+          display: block;
+          margin-right: 6.6666666667%;
+          width: 73.3333333333%; }
+          #main footer div.right:last-child {
+            margin-right: 0; } }
 
 .container {
   max-width: 68em;
@@ -804,11 +807,11 @@ div#usa {
   background-color: #EAEDF1;
   padding: 2em 0; }
   .hero > .container > .hero--content {
-    margin-left: 16.8421052632%;
     float: left;
     display: block;
     margin-right: 1.0526315789%;
     width: 66.3157894737%;
+    margin-left: 16.8421052632%;
     /*  @include media($large) {
         @include shift(2);
         @include span-columns(20)
@@ -845,71 +848,55 @@ div#usa {
 @media screen and (max-width: 30em) {
   .hero {
     padding: 2em 0; } }
-#main.agencies ul {
-  padding: 0; }
-  #main.agencies ul a {
-    color: black;
-    text-decoration: none; }
-  #main.agencies ul li {
-    list-style-type: none;
-    margin: 0;
-    padding: 0;
-    margin-bottom: 50px;
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 100%; }
-    #main.agencies ul li:last-child {
-      margin-right: 0; }
-    #main.agencies ul li .agencies--name {
-      float: left;
-      display: block;
-      margin-right: 1.0526315789%;
-      width: 32.6315789474%; }
-      #main.agencies ul li .agencies--name:last-child {
-        margin-right: 0; }
-      @media screen and (max-width: 30em) {
-        #main.agencies ul li .agencies--name {
-          float: left;
-          display: block;
-          margin-right: 6.6666666667%;
-          width: 100%; }
-          #main.agencies ul li .agencies--name:last-child {
-            margin-right: 0; } }
-      #main.agencies ul li .agencies--name h3 {
-        padding: 0 0 0.5em 0;
-        margin: 0;
-        font-size: 1em; }
-        @media screen and (max-width: 30em) {
-          #main.agencies ul li .agencies--name h3 {
-            font-size: 1.5em; } }
-    #main.agencies ul li .agencies--description {
-      float: left;
-      display: block;
-      margin-right: 1.0526315789%;
-      width: 66.3157894737%; }
-      #main.agencies ul li .agencies--description:last-child {
-        margin-right: 0; }
-      @media screen and (max-width: 30em) {
-        #main.agencies ul li .agencies--description {
-          float: left;
-          display: block;
-          margin-right: 6.6666666667%;
-          width: 100%; }
-          #main.agencies ul li .agencies--description:last-child {
-            margin-right: 0; } }
-
 .fa {
   color: #00BFE7; }
 
-.learn, .about {
+.content {
   float: left;
   display: block;
   margin-right: 1.0526315789%;
   width: 66.3157894737%;
   margin-left: 16.8421052632%; }
-  .learn:last-child, .about:last-child {
+  .content:last-child {
     margin-right: 0; }
+
+.searchresults {
+  float: left;
+  display: block;
+  margin-right: 1.0526315789%;
+  width: 66.3157894737%;
+  margin-left: 16.8421052632%;
+  /*  @include media($large) {
+      @include shift(2);
+      @include span-columns(20)
+    }*/ }
+  .searchresults:last-child {
+    margin-right: 0; }
+  @media screen and (max-width: 48em) {
+    .searchresults {
+      margin-left: 4.2105263158%;
+      float: left;
+      display: block;
+      margin-right: 2.1276595745%;
+      width: 82.9787234043%; }
+      .searchresults:last-child {
+        margin-right: 0; } }
+  @media screen and (max-width: 30em) {
+    .searchresults {
+      margin-left: 0%;
+      float: left;
+      display: block;
+      margin-right: 6.6666666667%;
+      width: 100%; }
+      .searchresults:last-child {
+        margin-right: 0; } }
+  .searchresults h1 {
+    font-size: 1.8em;
+    padding-top: 1em; }
+  .searchresults h2 {
+    font-size: 1.2em; }
+  .searchresults li {
+    padding: 0.5em 0; }
 
 #main.landing .contact h3 {
   margin-top: 30px;
@@ -1009,7 +996,8 @@ div#usa {
 #main.landing .department .contact_type h3 {
   margin-bottom: 5px; }
 #main.landing .inaccurate {
-  clear: both; }
+  clear: both;
+  padding-bottom: 2em; }
 
 form.request input.upto[type=text] {
   width: 80px;
@@ -1082,7 +1070,6 @@ input.agency {
 .pure-menu .pure-menu-selected a {
   border-bottom: 0.3em solid #333; }
 
-/* todo: error/success states still need styling */
 /* error message next to submit button */
 div.request.error {
   display: none;

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -617,7 +617,8 @@ body > header {
     margin: 1em 0 0.8em; }
   body > header #logo {
     float: left;
-    color: #0067BA; }
+    color: #0067BA;
+    padding-right: 1em; }
     body > header #logo a {
       color: #0067BA; }
     body > header #logo strong {

--- a/foia_hub/static/css/main.css
+++ b/foia_hub/static/css/main.css
@@ -445,7 +445,7 @@ a {
     outline: none; }
 
 hr {
-  border-bottom: 1px solid #323A45;
+  border-bottom: 1px solid #CCCCCC;
   border-left: none;
   border-right: none;
   border-top: none;
@@ -457,7 +457,7 @@ picture {
   max-width: 100%; }
 
 blockquote {
-  border-left: 2px solid #323A45;
+  border-left: 2px solid #CCCCCC;
   color: #525f71;
   margin: 1.5em 0;
   padding-left: 0.75em; }
@@ -469,8 +469,8 @@ cite {
     content: "\2014 \00A0"; }
 
 fieldset {
-  background: #475363;
-  border: 1px solid #323A45;
+  background: #e6e6e6;
+  border: 1px solid #CCCCCC;
   margin: 0 0 0.75em 0;
   padding: 1.5em; }
 
@@ -500,7 +500,7 @@ select[multiple=multiple] {
   transition: border-color;
   background-color: white;
   border-radius: 3px;
-  border: 1px solid #323A45;
+  border: 1px solid #CCCCCC;
   box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
   font-family: "proxima-nova", "proxima nova", "open sans", arial, sans-serif;
   font-size: 1em;
@@ -510,7 +510,7 @@ select[multiple=multiple] {
   textarea:hover,
   input[type="email"]:hover, input[type="number"]:hover, input[type="password"]:hover, input[type="search"]:hover, input[type="tel"]:hover, input[type="text"]:hover, input[type="url"]:hover, input[type="color"]:hover, input[type="date"]:hover, input[type="datetime"]:hover, input[type="datetime-local"]:hover, input[type="month"]:hover, input[type="time"]:hover, input[type="week"]:hover,
   select[multiple=multiple]:hover {
-    border-color: #1d2127; }
+    border-color: #b3b3b3; }
   textarea:focus,
   input[type="email"]:focus, input[type="number"]:focus, input[type="password"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="text"]:focus, input[type="url"]:focus, input[type="color"]:focus, input[type="date"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="week"]:focus,
   select[multiple=multiple]:focus {
@@ -549,13 +549,13 @@ table {
   width: 100%; }
 
 th {
-  border-bottom: 1px solid #121519;
+  border-bottom: 1px solid #a6a6a6;
   font-weight: bold;
   padding: 0.75em 0;
   text-align: left; }
 
 td {
-  border-bottom: 1px solid #323A45;
+  border-bottom: 1px solid #CCCCCC;
   padding: 0.75em 0; }
 
 tr,
@@ -900,9 +900,9 @@ div#usa {
           width: 100%; }
           #main.agencies ul li .agencies--description:last-child {
             margin-right: 0; } }
-      #main.agencies ul li .agencies--description p {
-        margin: 0;
-        padding: 0; }
+
+.fa {
+  color: #00BFE7; }
 
 #main.landing .contact h3 {
   margin-top: 30px;
@@ -913,122 +913,92 @@ div#usa {
   padding: 0;
   margin: 0; }
 #main.landing .header {
-  margin-top: 20px; }
+  margin: 1em 0; }
   #main.landing .header h1 {
     margin: 0;
     padding: 0;
     margin-top: 10px;
     font-size: 2.4em; }
-#main.landing .department {
-  padding-bottom: 20px;
-  border-bottom: 1px solid #e5e5e5; }
-  #main.landing .department:after {
-    content: "";
-    display: table;
-    clear: both; }
-#main.landing .department .description {
+#main.landing .department .department--container {
   float: left;
   display: block;
   margin-right: 1.0526315789%;
   width: 57.8947368421%; }
-  #main.landing .department .description:last-child {
+  #main.landing .department .department--container:last-child {
     margin-right: 0; }
-  @media screen and (max-width: 30em) {
-    #main.landing .department .description {
+  @media screen and (max-width: 48em) {
+    #main.landing .department .department--container {
       float: left;
       display: block;
-      margin-right: 6.6666666667%;
+      margin-right: 2.1276595745%;
       width: 100%; }
-      #main.landing .department .description:last-child {
+      #main.landing .department .department--container:last-child {
         margin-right: 0; } }
+#main.landing .department h2 {
+  font-size: 1.6em; }
+#main.landing .department h3 {
+  font-size: 1.05em; }
+#main.landing .department hr {
+  border-bottom: 1px solid #323A45; }
 #main.landing .department .resources {
   float: left;
   display: block;
   margin-right: 1.0526315789%;
-  width: 41.0526315789%; }
+  width: 36.8421052632%;
+  margin-left: 4.2105263158%;
+  padding: 1em;
+  background-color: white; }
   #main.landing .department .resources:last-child {
     margin-right: 0; }
+  @media screen and (max-width: 48em) {
+    #main.landing .department .resources {
+      float: left;
+      display: block;
+      margin-right: 2.1276595745%;
+      width: 100%;
+      margin-left: 0%; }
+      #main.landing .department .resources:last-child {
+        margin-right: 0; } }
   @media screen and (max-width: 30em) {
     #main.landing .department .resources {
       float: left;
       display: block;
       margin-right: 6.6666666667%;
       width: 100%;
-      padding-left: none; }
+      margin-left: 0%; }
       #main.landing .department .resources:last-child {
         margin-right: 0; } }
-#main.landing .details {
-  padding-top: 25px; }
-  #main.landing .details:after {
-    content: "";
-    display: table;
-    clear: both; }
-#main.landing .details .offices, #main.landing .details .left {
-  float: left;
-  display: block;
-  margin-right: 1.0526315789%;
-  width: 57.8947368421%; }
-  #main.landing .details .offices:last-child, #main.landing .details .left:last-child {
-    margin-right: 0; }
-  @media screen and (max-width: 30em) {
-    #main.landing .details .offices, #main.landing .details .left {
-      float: left;
-      display: block;
-      margin-right: 6.6666666667%;
-      width: 100%; }
-      #main.landing .details .offices:last-child, #main.landing .details .left:last-child {
-        margin-right: 0; } }
-#main.landing .details .contact, #main.landing .details .right {
-  float: left;
-  display: block;
-  margin-right: 1.0526315789%;
-  width: 41.0526315789%; }
-  #main.landing .details .contact:last-child, #main.landing .details .right:last-child {
-    margin-right: 0; }
-  @media screen and (max-width: 30em) {
-    #main.landing .details .contact, #main.landing .details .right {
-      float: left;
-      display: block;
-      margin-right: 6.6666666667%;
-      width: 100%; }
-      #main.landing .details .contact:last-child, #main.landing .details .right:last-child {
-        margin-right: 0; } }
-#main.landing .details header h2 {
-  font-size: 2em; }
-#main.landing .resource_type, #main.landing .contact_type {
-  margin: 15px 0; }
-  #main.landing .resource_type .fa:before, #main.landing .contact_type .fa:before {
-    font-size: 2em; }
-  #main.landing .resource_type .icon, #main.landing .contact_type .icon {
-    float: left;
-    display: block;
-    margin-right: 1.0526315789%;
-    width: 7.3684210526%;
-    font-size: 0.95em;
-    text-align: center;
-    margin-right: 1em; }
-    #main.landing .resource_type .icon:last-child, #main.landing .contact_type .icon:last-child {
-      margin-right: 0; }
-  #main.landing .resource_type .subdetails, #main.landing .contact_type .subdetails {
-    display: inline-block;
-    overflow: hidden; }
-  #main.landing .resource_type ul, #main.landing .resource_type li, #main.landing .contact_type ul, #main.landing .contact_type li {
-    list-style-type: none;
-    list-style-position: outside;
-    margin: 0;
-    padding: 0; }
-#main.landing .details .offices ul, #main.landing .details .offices li {
+#main.landing .department .description p {
+  margin: 1.2em 0;
+  font-size: 1.2em; }
+#main.landing .department .details .offices ul, #main.landing .department .details .offices li {
   list-style-type: none;
   list-style-position: outside;
   margin: 0;
   padding: 0; }
-#main.landing .details .offices li {
+#main.landing .department .details .offices li {
   margin: 10px 0;
   font-size: 1.2em;
   line-height: 30px; }
-#main.landing .resource_type h3 {
+#main.landing .department .resource_type, #main.landing .department .contact_type {
+  margin: 15px 0; }
+  #main.landing .department .resource_type .icon, #main.landing .department .contact_type .icon {
+    float: left;
+    text-align: center;
+    margin-right: 2em;
+    width: 24px; }
+    #main.landing .department .resource_type .icon .fa, #main.landing .department .contact_type .icon .fa {
+      font-size: 1.8em; }
+  #main.landing .department .resource_type .subdetails, #main.landing .department .contact_type .subdetails {
+    overflow: hidden; }
+  #main.landing .department .resource_type ul, #main.landing .department .resource_type li, #main.landing .department .contact_type ul, #main.landing .department .contact_type li {
+    list-style-type: none;
+    list-style-position: outside;
+    margin: 0;
+    padding: 0; }
+#main.landing .department .resource_type h3 {
   font-size: 1em; }
-#main.landing .contact_type h3 {
+#main.landing .department .contact_type h3 {
   margin-bottom: 5px; }
 #main.landing .inaccurate p {
   font-size: 1em; }

--- a/foia_hub/static/sass/base/_typography.scss
+++ b/foia_hub/static/sass/base/_typography.scss
@@ -28,20 +28,20 @@ h6 {
    }
 }
 
-h1 {
-  font-size: $h1-font-size;
-}
-
-h2 {
-  font-size: $h2-font-size;
-}
-
 h1, h2, h3, h4, h5, h6 {
   em {
     border-bottom: 0.15em solid $aqua-blue;
     line-height: $header-line-height * 1.25;
     font-style: normal;
   }
+}
+
+h1 {
+  font-size: $h1-font-size;
+}
+
+h2 {
+  font-size: $h2-font-size;
 }
 
 h3 {

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -65,7 +65,7 @@ $notice-color: lighten($base-accent-color, 40);
 $success-color: $light-green;
 
 // Border color
-$base-border-color: $dark-gray;
+$base-border-color: $medium-gray;
 $base-border: 1px solid $base-border-color;
 
 // Forms

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -7,8 +7,10 @@ $header-font-family: $base-font-family;
 // Font Sizes
 $base-font-size: 1em;
 $h1-font-size: $base-font-size * 2.25;
-$h2-font-size: $base-font-size * 2;
-$h3-font-size: $base-font-size * 1.75;
+// $h2-font-size: $base-font-size * 2;
+$h2-font-size: $base-font-size * 1.5;
+// $h3-font-size: $base-font-size * 1.75;
+$h3-font-size: $base-font-size * 1.125;
 $h4-font-size: $base-font-size * 1.5;
 $h5-font-size: $base-font-size * 1.25;
 $h6-font-size: $base-font-size;

--- a/foia_hub/static/sass/base/_variables.scss
+++ b/foia_hub/static/sass/base/_variables.scss
@@ -46,7 +46,7 @@ $light-gray: #EAEDF1; // Background
 $medium-gray: #CCCCCC; // Rules 2
 
 // Background Color
-$base-background-color: white;
+$base-background-color: $light-gray;
 
 // Font Colors
 $base-font-color: $dark-gray;

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -263,14 +263,16 @@ div#usa {
         @include media($small) {
           @include span-columns(4 of 4);
         }  
-        p {margin: 0; padding: 0;}
       }
     }
   }
 }
 
-#main.landing {
+.fa {
+  color: $aqua-blue;
+}
 
+#main.landing {
   .contact {
     h3 {
       margin-top: 30px; margin-bottom: 10px;
@@ -283,8 +285,7 @@ div#usa {
   }
 
   .header {
-    margin-top: 20px;
-
+    margin: 1em 0;
     h1 {
       margin: 0; padding: 0;
       margin-top: 10px;
@@ -293,104 +294,103 @@ div#usa {
   }
 
   .department {
-    padding-bottom: 20px;
-    // display:inline-block;
-    @include clearfix();
-    border-bottom: 1px solid #e5e5e5;
-  }
 
-  .department .description {
+    .department--container {
     @include span-columns(14 of 24);
-      @include media($small) {
-        @include span-columns(4);
+    @include media($medium) {
+        @include span-columns(12);
       }
-  }
+    }
 
-  .department .resources {
-    @include span-columns(10 of 24);
-    //padding-left: 10px;
-    @include media($small) {
-      @include span-columns(4);
-      padding-left: none;
-    }    
-  }
+    h2 {
+      font-size: $h2-font-size * 0.8;
+    }
 
-  .details {
-    padding-top: 25px;
-    @include clearfix();
-  }
+    h3 {
+      font-size: $h3-font-size * 0.6;
+    }
 
-  .details .offices, .details .left {
-    @include span-columns(14);
+    hr {
+      border-bottom: 1px solid $dark-gray;
+    }
+
+    .resources {
+      @include span-columns(9 of 24);
+      @include shift(1);
+      padding: 1em;
+      //padding-left: 10px;
+      background-color: white;
+      @include media($medium) {
+          @include span-columns(12);
+          @include shift(0);
+        }
       @include media($small) {
         @include span-columns(4);
+        @include shift(0);
       }    
-  }
+    }
 
-  .details .contact, .details .right {
-    @include span-columns(10);
-        @include media($small) {
-        @include span-columns(4);
+    .description p {
+      margin: 1.2em 0;
+      font-size: $base-font-size * 1.2;
+    }
+    .details {
+     .offices {
+        ul, li {
+          list-style-type: none;
+          list-style-position: outside;
+          margin: 0; padding: 0;
+        }
+
+        li {
+          margin: 10px 0;
+          font-size: 1.2em;
+          line-height: 30px;
+        }
       }
-  }
 
-  .details header h2 {
-    font-size: 2em;
-  }
-
-  .resource_type, .contact_type {
-
-    margin: 15px 0;
-
-    .fa:before {
-      font-size: 2em;
     }
 
-    .icon {
-      @include span-columns(2 of 24);
-      font-size: 0.95em;
-      text-align:center;
-      margin-right:1em;
+    .resource_type, .contact_type {
+
+      margin: 15px 0;
+
+      .icon {
+        .fa {
+          font-size: 1.8em;
+        }
+        // @include span-columns(2 of 24);
+        float:left;
+        text-align:center;
+        margin-right:2em;
+        // position:absolute;
+        width:24px;
+      }
+
+      .subdetails {
+        // display:inline-block;
+        overflow:hidden;
+      }
+
+      ul, li {
+        list-style-type: none;
+        list-style-position: outside;
+        margin: 0; padding: 0;
+      }
     }
 
-    .subdetails {
-      display:inline-block;
-      overflow:hidden;
+    .resource_type {
+      h3 {
+        font-size: 1em;
+      }
     }
 
-    ul, li {
-      list-style-type: none;
-      list-style-position: outside;
-      margin: 0; padding: 0;
+    .contact_type {
+      h3 {
+        margin-bottom: 5px;
+      }
     }
-  }
-
-  .details .offices {
-    ul, li {
-      list-style-type: none;
-      list-style-position: outside;
-      margin: 0; padding: 0;
-    }
-
-    li {
-      margin: 10px 0;
-      font-size: 1.2em;
-      line-height: 30px;
-    }
-  }
-
-  .resource_type {
-    h3 {
-      font-size: 1em;
-    }
-  }
-
-  .contact_type {
-    h3 {
-      margin-bottom: 5px;
-    }
-  }
-
+}
   .inaccurate {
     //@include clearfix();
     //clear:both;

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -265,9 +265,11 @@ div#usa {
   color: $aqua-blue;
 }
 
-.content {
-//  @include inner(16);
-}
+  .learn, .about {
+    @include span-columns(16);
+    @include shift(4);
+  }
+
 #main.landing {
   .contact {
     h3 {

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -117,10 +117,6 @@ div#usa {
 }
 
 #main {
-  .content {
-    padding-top: 20px;
-  }
-
   .search {
     background: $dark-gray;
     color: $light-gray;
@@ -172,9 +168,6 @@ div#usa {
       }
       @include media($small) {
         @include span-columns(3);
-      }
-      p {
-
       }
     }
 
@@ -272,6 +265,9 @@ div#usa {
   color: $aqua-blue;
 }
 
+.content {
+//  @include inner(16);
+}
 #main.landing {
   .contact {
     h3 {
@@ -296,7 +292,7 @@ div#usa {
   .department {
 
     .department--container {
-    @include span-columns(14 of 24);
+    @include span-columns(15 of 24);
     @include media($medium) {
         @include span-columns(12);
       }
@@ -315,7 +311,7 @@ div#usa {
     }
 
     .resources {
-      @include span-columns(9 of 24);
+      @include span-columns(8 of 24);
       @include shift(1);
       padding: 1em;
       background-color: white;

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -144,32 +144,17 @@ div#usa {
     background-color: white;
     padding-top: 1em;
     div.left {
-      @include span-columns(2);
-      @include media($medium) {
-        @include span-columns(1);
-      }
-      @include media($small) {
-        @include span-columns(1);
-      }
-
+      float:left;
+      padding-right: 1em;
       img {
-        width: 100%;
-        height: 100%;
+        width: 32px;
+        height: 32px;
       }
     }
 
     div.right {
-      @include span-columns(21);
-      @include shift(1);
-      @include media($medium) {
-        @include span-columns(9 of 12);
-        @include shift(0);
-      }
-      @include media($small) {
-        @include span-columns(3);
-      }
+    float:left;
     }
-
   }
 }
 
@@ -234,7 +219,7 @@ div#usa {
   @include inner(16);
   h1 {
     font-size: $h1-font-size * 0.8;
-    padding-top: 1em;
+    padding: 1em 0;
   }
   h2 {
     font-size: $h2-font-size * 0.6;
@@ -242,6 +227,10 @@ div#usa {
   li {
     padding: 0.5em 0;
   }
+}
+
+.breadcrumbs {
+    margin: 1em 0;
 }
 
 #main.landing {
@@ -253,15 +242,6 @@ div#usa {
       list-style-type: none;
       list-style-position: outside;
       padding: 0; margin: 0;
-    }
-  }
-
-  .header {
-    margin: 1em 0;
-    h1 {
-      margin: 0; padding: 0;
-      margin-top: 10px;
-      font-size: 2.4em;
     }
   }
 
@@ -369,6 +349,10 @@ div#usa {
     //@include clearfix();
   }
 
+}
+
+.department__decentralized {
+  @include inner(16);
 }
 
 form.request {

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -98,7 +98,7 @@ div#usa {
   padding: 0.25em 0;
   .usa--content {
     font-size: 0.8em;
-    font-weight: 800;
+    font-weight: 700;
   }
   .official { float:left; }
   .alpha {float:right; }
@@ -114,8 +114,6 @@ div#usa {
 }
 
 #main {
-  min-height: 99%;
-  position: relative;
   .search {
     background: $dark-gray;
     color: $light-gray;
@@ -211,8 +209,8 @@ div#usa {
 }
 
 .content {
-  @include span-columns(16);
   @include shift(4);
+  @include inner(16);
 }
 
 .searchresults {

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -25,9 +25,6 @@ body > header {
 
 #topnav nav {
     ul {
-      @include media($small) {
-//        @include span-columns(3);
-      }
       li {
         display: inline-block;
         padding: 0 10px;
@@ -40,7 +37,7 @@ body > header {
             padding-bottom: 0;
           }
       }
-      a:hover, a.active {
+      a:hover, a.active, #logo:hover {
         border-bottom: 0.3em solid $aqua-blue;
         color: $dark-gray;
         @include media($small) {
@@ -61,8 +58,8 @@ body > header {
  * $columns should always be an even number 
  */
 @mixin inner($columns) {
-  @include shift( ( 24 - $columns )/ 2 );
   @include span-columns( $columns );
+  @include shift( ( 24 - $columns ) / 2 );
 /*  @include media($large) {
     @include shift(2);
     @include span-columns(20)
@@ -117,6 +114,8 @@ div#usa {
 }
 
 #main {
+  min-height: 99%;
+  position: relative;
   .search {
     background: $dark-gray;
     color: $light-gray;
@@ -222,53 +221,28 @@ div#usa {
   }
 }
 
-#main.agencies {
-
-  ul {
-    padding: 0;
-    a {
-      color: black;
-      text-decoration: none;
-    }
-    li {
-      list-style-type: none;
-      margin: 0; padding: 0;
-      margin-bottom: 50px;
-      @include span-columns(24);
-      .agencies--name {
-        @include span-columns(8);
-        @include media($small) {
-          @include span-columns(4 of 4);
-          // text-align: center;
-        }  
-        h3 {
-          padding: 0 0 0.5em 0; margin: 0;
-          font-size: 1em;
-          @include media($small) {
-            font-size: 1.5em;
-          }
-        }
-      }
-
-      .agencies--description {
-        @include span-columns(16);
-        //@include shift(2);
-        @include media($small) {
-          @include span-columns(4 of 4);
-        }  
-      }
-    }
-  }
-}
-
 .fa {
   color: $aqua-blue;
 }
 
-  .learn, .about {
-    @include span-columns(16);
-    @include shift(4);
+.content {
+  @include span-columns(16);
+  @include shift(4);
+}
+
+.searchresults {
+  @include inner(16);
+  h1 {
+    font-size: $h1-font-size * 0.8;
+    padding-top: 1em;
   }
+  h2 {
+    font-size: $h2-font-size * 0.6;
+  }
+  li {
+    padding: 0.5em 0;
+  }
+}
 
 #main.landing {
   .contact {
@@ -391,6 +365,7 @@ div#usa {
 }
   .inaccurate {
     clear:both;
+    padding-bottom:2em;
     //@include clearfix();
   }
 
@@ -458,8 +433,6 @@ input.agency { width: 100% }
 
 .pure-menu .pure-menu-selected a { border-bottom: 0.3em solid #333;}
 
-
-/* todo: error/success states still need styling */
 
 /* error message next to submit button */
 div.request.error {

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -6,11 +6,8 @@
 @import "neat";
 
 
-body {
-  padding-bottom: 20px;
-}
-
 body > header {
+  background-color: white;
   border-bottom: 1px solid #dedede;
   a:hover {text-decoration: none;}
   #topnav {
@@ -149,7 +146,8 @@ div#usa {
   }
 
   footer {
-    margin-top: 1em;
+    background-color: white;
+    padding-top: 1em;
     div.left {
       @include span-columns(2);
       @include media($medium) {

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -18,6 +18,7 @@ body > header {
     // font-weight: normal;
     // font-size: 2em;
     color: $blue;
+    padding-right: 1em;
     a { color: $blue; }
     strong {font-weight: 800;}
     em { color: #cc2211; font-style: normal;}

--- a/foia_hub/static/sass/main.scss
+++ b/foia_hub/static/sass/main.scss
@@ -310,7 +310,7 @@ div#usa {
       font-size: $h3-font-size * 0.6;
     }
 
-    hr {
+    .details > hr {
       border-bottom: 1px solid $dark-gray;
     }
 
@@ -318,8 +318,8 @@ div#usa {
       @include span-columns(9 of 24);
       @include shift(1);
       padding: 1em;
-      //padding-left: 10px;
       background-color: white;
+      box-shadow: 4px 4px 8px #CCC;
       @include media($medium) {
           @include span-columns(12);
           @include shift(0);
@@ -392,12 +392,8 @@ div#usa {
     }
 }
   .inaccurate {
+    clear:both;
     //@include clearfix();
-    //clear:both;
-    //@include clearfix();
-    p {
-      font-size: 1em;
-    }
   }
 
 }

--- a/foia_hub/templates/about.html
+++ b/foia_hub/templates/about.html
@@ -4,7 +4,7 @@
 <div class="container">
     <section class="content">
         <div class="about">
-            <h1> FOIA Hub aims to improve the FOIA request experience. </h1>
+            <h1><em>FOIA Hub aims to improve the FOIA request experience.</em></h1>
 
             <p>
             The Freedom of Information Act (FOIA) grants the public (everyone!) the
@@ -19,9 +19,9 @@
             by <a href="https://18f.gsa.gov">18F</a>.
             </p>
 
-            <h2> Features </h2>
+            <h2>Features</h2>
 
-            <h3> <span class="fa fa-phone-square"></span> Up-to-date contact information </h3>
+            <h3><span class="fa fa-phone-square"></span>Up-to-date contact information</h3>
 
             <p>
             FOIA Hub provides a single, easily searchable source for contact
@@ -35,11 +35,11 @@
 
             <h3><span class="fa fa-search"></span>Search</h3>
 
-            <p> Navigating the federal government hierarchy to determine where to
-            submit a FOIA request is not easy. </p>
+            <p>Navigating the federal government hierarchy to determine where to
+            submit a FOIA request is not easy.</p>
 
-            <p> FOIA Hub provides a number of search options to help requesters
-            navigate to the appropriate agency or office within. </p>
+            <p>FOIA Hub provides a number of search options to help requesters
+            navigate to the appropriate agency or office within.</p>
 
             <h4> Keyword Search </h4>
 
@@ -67,8 +67,8 @@
 
             <h2> Feedback </h2>
 
-            <p> We welcome and encourage feedback! Please reach out to us: <a
-            href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a> </p>
+            <p>We welcome and encourage feedback! Please reach out to us: <a
+            href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a></p>
 
             <h2>More about this project</h2>
 

--- a/foia_hub/templates/about.html
+++ b/foia_hub/templates/about.html
@@ -3,87 +3,87 @@
 {% block body %}
 <div class="container">
     <section class="content">
+        <div class="about">
+            <h1> FOIA Hub aims to improve the FOIA request experience. </h1>
 
-        <h1> FOIA Hub aims to improve the FOIA request experience. </h1>
+            <p>
+            The Freedom of Information Act (FOIA) grants the public (everyone!) the
+            right to access information from the federal government. The FOIA process
+            requires the public to submit a request for information or records within a
+            specific federal agency.
+            </p>
 
-        <p>
-        The Freedom of Information Act (FOIA) grants the public (everyone!) the
-        right to access information from the federal government. The FOIA process
-        requires the public to submit a request for information or records within a
-        specific federal agency.
-        </p>
+            <p>
+            FOIA Hub is an online tool to guide users to up-to-date FOIA contact and
+            request information across the federal government. It is a work in progress
+            by <a href="https://18f.gsa.gov">18F</a>.
+            </p>
 
-        <p>
-        FOIA Hub is an online tool to guide users to up-to-date FOIA contact and
-        request information across the federal government. It is a work in progress
-        by <a href="https://18f.gsa.gov">18F</a>.
-        </p>
+            <h2> Features </h2>
 
-        <h2> Features </h2>
+            <h3> <span class="fa fa-phone-square"></span> Up-to-date contact information </h3>
 
-        <h3> <span class="fa fa-phone-square"></span> Up-to-date contact information </h3>
+            <p>
+            FOIA Hub provides a single, easily searchable source for contact
+            information for FOIA offices within various agencies and components of the
+            United States government.
+            </p>
 
-        <p>
-        FOIA Hub provides a single, easily searchable source for contact
-        information for FOIA offices within various agencies and components of the
-        United States government.
-        </p>
+            <p>
+            Links are provided to an agency's online FOIA request form where available.
+            </p>
 
-        <p>
-        Links are provided to an agency's online FOIA request form where available.
-        </p>
+            <h3><span class="fa fa-search"></span>Search</h3>
 
-        <h3> <span class="fa fa-search"></span> Search </h3>
+            <p> Navigating the federal government hierarchy to determine where to
+            submit a FOIA request is not easy. </p>
 
-        <p> Navigating the federal government hierarchy to determine where to
-        submit a FOIA request is not easy. </p>
+            <p> FOIA Hub provides a number of search options to help requesters
+            navigate to the appropriate agency or office within. </p>
 
-        <p> FOIA Hub provides a number of search options to help requesters
-        navigate to the appropriate agency or office within. </p>
+            <h4> Keyword Search </h4>
 
-        <h4> Keyword Search </h4>
+            <p>
+            You can search by various keywords. For example, a search for 'benzene'
+            brings up the Environmental Protection Agency. Or a search for 'criminal
+            laws' brings up the Bureau of Alcohol, Tobacco, Firearms and Explosives.
+            </p>
 
-        <p>
-        You can search by various keywords. For example, a search for 'benzene'
-        brings up the Environmental Protection Agency. Or a search for 'criminal
-        laws' brings up the Bureau of Alcohol, Tobacco, Firearms and Explosives.
-        </p>
+            <h4> Acronym Search </h4>
 
-        <h4> Acronym Search </h4>
-
-        <p>
-        Some agencies are better known by their acronym. You can search for an
-        agency by acronym. 'FBI' brings up the Federal Bureau of Investigation.
-        </p>
+            <p>
+            Some agencies are better known by their acronym. You can search for an
+            agency by acronym. 'FBI' brings up the Federal Bureau of Investigation.
+            </p>
 
 
-        <h3> <span class="fa fa-bookmark"></span> FOIA Libraries </h3>
+            <h3> <span class="fa fa-book"></span> FOIA Libraries </h3>
 
-        <p>
-        Many agencies provide oft-requested responsive documents in online
-        libraries, or "reading rooms". It might help a potential requester
-        to check those libraries before submitting a request.
-        </p>
+            <p>
+            Many agencies provide oft-requested responsive documents in online
+            libraries, or "reading rooms". It might help a potential requester
+            to check those libraries before submitting a request.
+            </p>
 
-        <h2> Feedback </h2>
+            <h2> Feedback </h2>
 
-        <p> We welcome and encourage feedback! Please reach out to us: <a
-        href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a> </p>
+            <p> We welcome and encourage feedback! Please reach out to us: <a
+            href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a> </p>
 
-        <h2>More about this project</h2>
+            <h2>More about this project</h2>
 
-        <p>
-          Our work is one of a number of <a
-          href="http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf">commitments</a>
-          towards modernizing the Freedom of Information Act. We are currently in
-          the <a href="https://18f.github.io/dashboard/stages/">alpha</a> stage of
-          development.
-        </p>
+            <p>
+              Our work is one of a number of <a
+              href="http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf">commitments</a>
+              towards modernizing the Freedom of Information Act. We are currently in
+              the <a href="https://18f.github.io/dashboard/stages/">alpha</a> stage of
+              development.
+            </p>
 
-        <p>
-            Developers can find additional technical information <a href="/developers">here.</a>
-        </p>
-
+            <p>
+                Developers can find additional technical information <a href="/developers">here.</a>
+            </p>
+        </div>
     </section>
-
+</div>
 {% endblock %}

--- a/foia_hub/templates/contacts/index.html
+++ b/foia_hub/templates/contacts/index.html
@@ -6,15 +6,16 @@
 {% include "includes/search.html" %}
 
 <div class="container">
-  <section class="listing">
+  <section class="searchresults">
 
   {% if agencies %}
+  <h1>Search results</h1>
+  <hr>
     <ul>
       {% for agency in agencies %}
-        <a href="/contacts/{{agency.slug }}">
           <li>
             <div class="agencies--name">
-              <h3>{{ agency.name }}</h3>
+              <h2><a href="/contacts/{{agency.slug }}">{{ agency.name }}</a></h2>
             </div>
             <div class="agencies--description">
               <p>
@@ -26,7 +27,6 @@
               </p>
             </div>
           </li>
-        </a>
       {% endfor %}
     </ul>
   {% else %}

--- a/foia_hub/templates/contacts/index.html
+++ b/foia_hub/templates/contacts/index.html
@@ -9,8 +9,8 @@
   <section class="searchresults">
 
   {% if agencies %}
-  <h1>Search results</h1>
-  <hr>
+  <h1><em>Search results</em></h1>
+  
     <ul>
       {% for agency in agencies %}
           <li>

--- a/foia_hub/templates/contacts/parent_profile.html
+++ b/foia_hub/templates/contacts/parent_profile.html
@@ -20,7 +20,7 @@
         Home &gt;
       </a>
     </div>
-    <h1>{{ profile.name }}</h1>
+    <h1><em>{{ profile.name }}</em></h1>
   </section>
 
   <section class="department">
@@ -31,28 +31,28 @@
         </p>
       {% endif %}
     </div>
-  </section>
 
-  <section class="details">
+    <section class="details">
 
-    <div class="offices">
-      <h2>
-        Make your FOIA request directly to the most relevant group or component:
-      </h2>
+      <div class="offices">
+        <h2>
+          Make your FOIA request directly to the most relevant group or component:
+        </h2>
 
-      <ul>
-        {% for office in profile.offices %}
-          <li>
-            <a href="/contacts/{{ office.slug }}">
-              {{ office.name }}
-            </a>
-          </li>
-        {% endfor %}
-      </ul>
+        <ul>
+          {% for office in profile.offices %}
+            <li>
+              <a href="/contacts/{{ office.slug }}">
+                {{ office.name }}
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
 
-    <div class="contact">
-      {% include 'contacts/contact.html' %}
-    </div>
+      <div class="contact">
+        {% include 'contacts/contact.html' %}
+      </div>
+    </section>
   </section>
 </div>
 

--- a/foia_hub/templates/contacts/parent_profile.html
+++ b/foia_hub/templates/contacts/parent_profile.html
@@ -14,16 +14,14 @@
 {# 'profile' here is known to be an agency with sub-offices. #}
 
 <div class="container">
-  <section class="header">
     <div class="breadcrumbs">
       <a href="/">
         Home &gt;
       </a>
     </div>
-    <h1><em>{{ profile.name }}</em></h1>
-  </section>
 
-  <section class="department">
+  <section class="department department__decentralized">
+    <h1 class="department--name"><em>{{ profile.name }}</em></h1>
     <div class="description">
       {% if profile.description %}
         <p>

--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -14,8 +14,7 @@
 {# 'profile' here can be an office, or an agency with no sub-offices. #}
 
 <div class="container">
-  <section class="header">
-    <div class="breadcrumbs">
+    <section class="breadcrumbs">
       <a href="/">
         Home &gt;
       </a>
@@ -28,137 +27,136 @@
           {{ profile.agency_name }} &gt;
         </a>
       {% endif %}
-    </div>
-  </section>
+    </section>
 
   <section class="department">
-  <div class="department--container">
-    <div class="description">
-      <h1><em>{{ profile.name }}</em></h1>
-      <p>
-        {% if profile.description %}
-          {{ profile.description }}
-        {% else %}
-          Here you can find some resources and contact information to file a request with this office.
+    <div class="department--container">
+      <div class="description">
+        <h1><em>{{ profile.name }}</em></h1>
+        <p>
+          {% if profile.description %}
+            {{ profile.description }}
+          {% else %}
+            Here you can find some resources and contact information to file a request with this office.
+          {% endif %}
+        </p>
+      </div>
+
+      <section class="details">
+
+        <h2>Submit a request</h2>
+
+        <hr>
+
+        {% if profile.request_form_url or (profile.emails|length > 0 and show_webform) %}
+         <div class="webform contact_type">
+            <div class="icon">
+                <span class="fa fa-desktop"></span>
+            </div>
+            <div class="subdetails">
+               <h3> Request online </h3>
+                <ul>
+                  <li><a
+                    {% if profile.request_form_url %}
+                      href="{{ profile.request_form_url }}"
+                    {% elif profile.emails|length>0 %}
+                      href="/request/{{ slug }}"
+                    {% endif %}
+                    >
+                      Submit a request via web
+                  </a></li>
+                </ul>
+            </div>
+          <hr>
+        </div>
         {% endif %}
-      </p>
-    </div>
 
-    <section class="details">
-
-      <h2>Submit a request</h2>
-
-      <hr>
-
-      {% if profile.request_form_url or (profile.emails|length > 0 and show_webform) %}
-       <div class="webform contact_type">
+        <div class="address contact_type">
           <div class="icon">
-              <span class="fa fa-desktop"></span>
+            <span class="fa fa-envelope-o"></span>
           </div>
           <div class="subdetails">
-             <h3> Request online </h3>
-              <ul>
-                <li><a
-                  {% if profile.request_form_url %}
-                    href="{{ profile.request_form_url }}"
-                  {% elif profile.emails|length>0 %}
-                    href="/request/{{ slug }}"
-                  {% endif %}
-                  >
-                    Submit a request via web
-                </a></li>
-              </ul>
-          </div>
-        <hr>
-      </div>
-      {% endif %}
-
-      <div class="address contact_type">
-        <div class="icon">
-          <span class="fa fa-envelope-o"></span>
-        </div>
-        <div class="subdetails">
-          <h3>Request by mail</h3>
-          <p>
-            {% for line in profile.address_lines %}
-              {{ line }}<br/>
-            {% endfor %}
-            {{ profile.street }}<br/>
-            {{ profile.city }}, {{ profile.state }} {{ profile.zip_code }}
-          </p>
-        </div>
-        <hr>
-      </div>
-
-
-      {% if profile.emails %}
-        <div class="email contact_type">
-          <div class="icon">
-            <span class="fa fa-at"></span>
-          </div>
-          <div class="subdetails">
-            <h3>
-              Request by email
-            </h3>
-            <ul>
-              {% for email in profile.emails %}
-                <li>
-                  <a href="mailto:{{ email }}">
-                    {{ email }}
-                  </a>
-                </li>
+            <h3>Request by mail</h3>
+            <p>
+              {% for line in profile.address_lines %}
+                {{ line }}<br/>
               {% endfor %}
-            </ul>
-          </div>
-        <hr>
-        </div>
-      {% endif %}
-
-      {% if profile.fax %}
-        <div class="fax contact_type">
-          <div class="icon">
-            <span class="fa fa-fax"></span>
-          </div>
-          <div class="subdetails">
-            <h3>Request by FAX</h3>
-            <ul>
-              <li>{{ profile.fax }}</li>
-            </ul>
+              {{ profile.street }}<br/>
+              {{ profile.city }}, {{ profile.state }} {{ profile.zip_code }}
+            </p>
           </div>
           <hr>
         </div>
+
+
+        {% if profile.emails %}
+          <div class="email contact_type">
+            <div class="icon">
+              <span class="fa fa-at"></span>
+            </div>
+            <div class="subdetails">
+              <h3>
+                Request by email
+              </h3>
+              <ul>
+                {% for email in profile.emails %}
+                  <li>
+                    <a href="mailto:{{ email }}">
+                      {{ email }}
+                    </a>
+                  </li>
+                {% endfor %}
+              </ul>
+            </div>
+          <hr>
+          </div>
+        {% endif %}
+
+        {% if profile.fax %}
+          <div class="fax contact_type">
+            <div class="icon">
+              <span class="fa fa-fax"></span>
+            </div>
+            <div class="subdetails">
+              <h3>Request by FAX</h3>
+              <ul>
+                <li>{{ profile.fax }}</li>
+              </ul>
+            </div>
+            <hr>
+          </div>
+        {% endif %}
+      </section><!--/details-->
+    </div><!--/department--container-->
+    <div class="resources">
+      {% include 'contacts/contact.html' %}
+
+      {% if profile.simple_processing_time or profile.complex_processing_time %}
+        <div class="processing resource_type">
+          <div class="icon">
+            <span class="fa fa-clock-o"></span>
+          </div>
+          <div class="subdetails">
+            <h3>Median processing time</h3>
+            <ul>
+              {% if profile.simple_processing_time %}
+                <li>
+                  Simple requests:
+                  {{ profile.simple_processing_time|int }} working days
+                </li>
+              {% endif %}
+
+              {% if profile.complex_processing_time %}
+                <li>
+                  Complex requests:
+                  {{ profile.complex_processing_time|int }} working days
+                </li>
+              {% endif %}
+            </ul>
+          </div>
+        </div>
       {% endif %}
-    </section><!--/details-->
-  </div><!--/department--container-->
-  <div class="resources">
-    {% include 'contacts/contact.html' %}
-
-    {% if profile.simple_processing_time or profile.complex_processing_time %}
-      <div class="processing resource_type">
-        <div class="icon">
-          <span class="fa fa-clock-o"></span>
-        </div>
-        <div class="subdetails">
-          <h3>Median processing time</h3>
-          <ul>
-            {% if profile.simple_processing_time %}
-              <li>
-                Simple requests:
-                {{ profile.simple_processing_time|int }} working days
-              </li>
-            {% endif %}
-
-            {% if profile.complex_processing_time %}
-              <li>
-                Complex requests:
-                {{ profile.complex_processing_time|int }} working days
-              </li>
-            {% endif %}
-          </ul>
-        </div>
-      </div>
-    {% endif %}
-  </div>
+    </div>
   </section><!--/department-->
 
   <section class="inaccurate">

--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -69,6 +69,7 @@
                 </a></li>
               </ul>
           </div>
+        <hr>
       </div>
       {% endif %}
 
@@ -86,7 +87,9 @@
             {{ profile.city }}, {{ profile.state }} {{ profile.zip_code }}
           </p>
         </div>
+        <hr>
       </div>
+
 
       {% if profile.emails %}
         <div class="email contact_type">
@@ -107,6 +110,7 @@
               {% endfor %}
             </ul>
           </div>
+        <hr>
         </div>
       {% endif %}
 
@@ -121,6 +125,7 @@
               <li>{{ profile.fax }}</li>
             </ul>
           </div>
+          <hr>
         </div>
       {% endif %}
     </section><!--/details-->

--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -29,12 +29,12 @@
         </a>
       {% endif %}
     </div>
-
-    <h1>{{ profile.name }}</h1>
   </section>
 
   <section class="department">
+  <div class="department--container">
     <div class="description">
+      <h1><em>{{ profile.name }}</em></h1>
       <p>
         {% if profile.description %}
           {{ profile.description }}
@@ -44,44 +44,12 @@
       </p>
     </div>
 
-    <div class="resources">
-      {% include 'contacts/contact.html' %}
+    <section class="details">
 
-      {% if profile.simple_processing_time or profile.complex_processing_time %}
-        <div class="processing resource_type">
-          <div class="icon">
-            <span class="fa fa-clock-o"></span>
-          </div>
-          <div class="subdetails">
-            <h3>Median processing time</h3>
-            <ul>
-              {% if profile.simple_processing_time %}
-                <li>
-                  Simple requests:
-                  {{ profile.simple_processing_time|int }} working days
-                </li>
-              {% endif %}
+      <h2>Submit a request</h2>
 
-              {% if profile.complex_processing_time %}
-                <li>
-                  Complex requests:
-                  {{ profile.complex_processing_time|int }} working days
-                </li>
-              {% endif %}
-            </ul>
-          </div>
-        </div>
-      {% endif %}
-    </div>
-  </section>
+      <hr>
 
-  <section class="details">
-
-    <header>
-      <h2>Submitting a request</h2>
-    </header>
-
-    <div class="left">
       {% if profile.request_form_url or (profile.emails|length > 0 and show_webform) %}
        <div class="webform contact_type">
           <div class="icon">
@@ -119,9 +87,7 @@
           </p>
         </div>
       </div>
-    </div>
 
-    <div class="right">
       {% if profile.emails %}
         <div class="email contact_type">
           <div class="icon">
@@ -157,8 +123,38 @@
           </div>
         </div>
       {% endif %}
-    </div>
-  </section>
+    </section><!--/details-->
+  </div><!--/department--container-->
+  <div class="resources">
+    {% include 'contacts/contact.html' %}
+
+    {% if profile.simple_processing_time or profile.complex_processing_time %}
+      <div class="processing resource_type">
+        <div class="icon">
+          <span class="fa fa-clock-o"></span>
+        </div>
+        <div class="subdetails">
+          <h3>Median processing time</h3>
+          <ul>
+            {% if profile.simple_processing_time %}
+              <li>
+                Simple requests:
+                {{ profile.simple_processing_time|int }} working days
+              </li>
+            {% endif %}
+
+            {% if profile.complex_processing_time %}
+              <li>
+                Complex requests:
+                {{ profile.complex_processing_time|int }} working days
+              </li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+  </section><!--/department-->
 
   <section class="inaccurate">
     <p>

--- a/foia_hub/templates/includes/footer.html
+++ b/foia_hub/templates/includes/footer.html
@@ -1,14 +1,16 @@
 
-<footer class="container">
-  <div class="left">
-    <a href="https://18f.gsa.gov">
-      <img src="/static/images/logo-18f.png" />
-    </a>
-  </div>
+<footer>
+  <div class="container">
+    <div class="left">
+      <a href="https://18f.gsa.gov">
+        <img src="/static/images/logo-18f.png" />
+      </a>
+    </div>
 
-  <div class="right">
-    <p>
-      Built <a href="https://github.com/18F/foia-hub">in the open</a> by <a href="https://18f.gsa.gov">18F</a>, a government services team in the <a href="http://gsa.gov">General Services Administration</a>.
-    </p>
+    <div class="right">
+      <p>
+        Built <a href="https://github.com/18F/foia-hub">in the open</a> by <a href="https://18f.gsa.gov">18F</a>, a government services team in the <a href="http://gsa.gov">General Services Administration</a>.
+      </p>
+    </div>
   </div>
 </footer>

--- a/foia_hub/templates/includes/nav.html
+++ b/foia_hub/templates/includes/nav.html
@@ -25,6 +25,10 @@
             {% if request and ('/about/' == request.path) %}class="active"{% endif %}
             href="/about/">About this Project
           </a></li>
+          <li><a
+            {% if request and ('/agencies/' == request.path) %}class="active"{% endif %}
+            href="/agencies/">Federal Agencies
+          </a></li>
         </ul>
       </nav>
     </div>

--- a/foia_hub/templates/index.html
+++ b/foia_hub/templates/index.html
@@ -8,18 +8,18 @@
 <div class="hero">
     <div class="container">
         <section class="hero--content">
-	        <h2><em>FOIA Hub is the first front door to the  United States Freedom of Information Act request process that includes current contact information for every federal agency.</em></h2>
+	        <h1><em>FOIA Hub is the first front door to the  United States Freedom of Information Act request process that includes current contact information for every federal agency.</em></h1>
 	        
 	        <hr>
             
-            <h2><em>What is FOIA?</em></h2>
+            <h1><em>What is FOIA?</em></h1>
             <p>The Freedom of Information Act, or FOIA, provides you the right to request access to government records. Under FOIA, government agencies are required to disclose any information requested unless it falls under a specific set of exemptions or exclusions.</p>
 			<a class="more" href="/learn/">Learn more about FOIA <i class="fa fa-arrow-right"></i></a>
 
 			<hr>
 
 			<section class="process">
-				<h2><em>How does the process work?</em></h2>
+				<h1><em>How does the process work?</em></h1>
 				<ol class="default">
 					<li>Submit a FOIA request directly to the agency you believe holds the information you seek.</li>
 					<li>The FOIA officials at that agency will (usually) email receipt of your request and begin looking for the requested records or point you to a public space where the records may already be accessed.</li>

--- a/foia_hub/templates/learn.html
+++ b/foia_hub/templates/learn.html
@@ -6,8 +6,8 @@
         <div class="learn">
             <h1><em>What is FOIA?</em></h1>
 
-            <nav>
-                <ul class="toc">
+            <nav class="toc">
+                <ul>
                     <li><a href="#why"><a href="">Why would I make a FOIA request?</a></li>
                     <li><a href="#what">What can I ask for?</a></li>
                     <li><a href="#form">Is there a special form I have to use to make a FOIA request?</a></li>

--- a/foia_hub/templates/learn.html
+++ b/foia_hub/templates/learn.html
@@ -8,13 +8,13 @@
 
             <nav class="toc">
                 <ul>
-                    <li><a href="#why"><a href="">Why would I make a FOIA request?</a></li>
-                    <li><a href="#what">What can I ask for?</a></li>
-                    <li><a href="#form">Is there a special form I have to use to make a FOIA request?</a></li>
-                    <li><a href="#how">How do I make a FOIA request?</a></li>
-                    <li><a href="#after">What happens after I make my FOIA request?</a></li>
-                    <li><a href="#when">How long does it take to fulfill my request?</a></li>
-                    <li><a href="#dispute">What happens if I’m not satisfied with the response I received?</a></li>
+                    <li><h3><a href="#why">Why would I make a FOIA request?</a></h3></li>
+                    <li><h3><a href="#what">What can I ask for?</a></h3></li>
+                    <li><h3><a href="#form">Is there a special form I have to use to make a FOIA request?</a></h3></li>
+                    <li><h3><a href="#how">How do I make a FOIA request?</a></h3></li>
+                    <li><h3><a href="#after">What happens after I make my FOIA request?</a></h3></li>
+                    <li><h3><a href="#when">How long does it take to fulfill my request?</a></h3></li>
+                    <li><h3><a href="#dispute">What happens if I’m not satisfied with the response I received?</a></h3></li>
                 </ul>
             </nav>
 
@@ -22,9 +22,11 @@
 
             <p>The public's right to request records has served as the backbone for information disclosure in the United States. Records released under FOIA have led to the publication of many important news stories and greater public awareness around government activities.</p>
 
-            <h2 id="why">Why would I make a FOIA request?</h2>
+            <h2 id="why"><em>Why would I make a FOIA request?</em></h2>
 
             <p>While the Federal Government makes a lot of information <a href="https://www.data.gov">available</a> in many <a href="http://foia.state.gov/Search/Search.aspx">places</a>, you may still seek information that has not already been publicly released. FOIA makes it possible to access records that are not yet publicly available.</p>
+
+            <hr />
 
             <h2 id="what">What can I ask for?</h2>
 
@@ -36,18 +38,24 @@
 
             <p>Your written description must be specific enough that agency FOIA professionals can understand what you are seeking and properly conduct a search. Information such as time periods, specific names, topics, or key words related to the information you are seeking will help inform the agency.</p>
 
+            <hr />
+            
             <h2 id="how">How do I make a FOIA request?</h2>
 
             <p>Requests must be submitted in writing, either electronically or in paper format, and should include a reasonable description of the information you are requesting and the format you prefer.</p>
 
             <p>The FOIA does not require agencies to do research for you, analyze data, answer written questions, or create records in response to your request. That means you may need to do some research before filing a request. An agency’s own website is a good place to start.</p>
 
+            <hr />
+            
             <h2 id="after">What happens after I make my FOIA request?</h2>
 
             <p>A lot happens behind the scenes after an agency receives your FOIA request. Agencies each have their own specific way of processing a request. The first step is to determine which offices may have responsive records and search for those records. Once an office has located records and provided them back to the FOIA shop, the FOIA team may consult subject matter experts, lawyers, or other agency officials to review them for release. This step may also include redacting any non-public information.</p>
 
             <p>Once the agency has completed this process, any public records will be released to you.</p>
 
+            <hr />
+            
             <h2 id="when">How long does it take to fulfill my request?</h2>
 
             <p>Response time varies between agencies and also depends on the complexity of the request. The standard time limit established by FOIA is 20 business days, but some requests are more complex and will require more time.</p>
@@ -56,6 +64,8 @@
 
             <p>Another option is to agree to a different timetable for processing the request. You can work with the agency’s FOIA Public Liaison or other FOIA contacts to discuss this option. You should always feel free to contact the agency to check on the status of your request. Agencies are required to provide an estimated response date upon request.</p>
 
+            <hr />
+            
             <h2 id="dispute">What happens if I’m not satisfied with the response I received?</h2>
 
             <p>If you disagree with agency’s decision on your request, you can file an appeal by writing to the agency. Agencies review appeals independently and inform you whether your appeal is granted or denied. FOIA also provides for a 20 business day time frame for appeal responses, but, similarly, response times vary based on an agency’s workload and the complexity of your appeal.</p>

--- a/foia_hub/templates/learn.html
+++ b/foia_hub/templates/learn.html
@@ -4,39 +4,51 @@
 <div class="container">
     <section class="content">
         <div class="learn">
-            <h2>What is FOIA?</h2>
+            <h1><em>What is FOIA?</em></h1>
+
+            <nav>
+                <ul class="toc">
+                    <li><a href="#why"><a href="">Why would I make a FOIA request?</a></li>
+                    <li><a href="#what">What can I ask for?</a></li>
+                    <li><a href="#form">Is there a special form I have to use to make a FOIA request?</a></li>
+                    <li><a href="#how">How do I make a FOIA request?</a></li>
+                    <li><a href="#after">What happens after I make my FOIA request?</a></li>
+                    <li><a href="#when">How long does it take to fulfill my request?</a></li>
+                    <li><a href="#dispute">What happens if I’m not satisfied with the response I received?</a></li>
+                </ul>
+            </nav>
 
             <p>Since 1966, the Freedom of Information Act (FOIA) has granted the public the right to request access to any agency records. Under FOIA, agencies are required to disclose any information requested unless it falls under a specific set of <a href="http://www.foia.gov/faq.html#exemptions">exemptions</a> or <a href="http://www.foia.gov/faq.html#exclusions">exclusions</a>.</p>
 
             <p>The public's right to request records has served as the backbone for information disclosure in the United States. Records released under FOIA have led to the publication of many important news stories and greater public awareness around government activities.</p>
 
-            <p><strong>Why would I make a FOIA request?</strong></p>
+            <h2 id="why">Why would I make a FOIA request?</h2>
 
             <p>While the Federal Government makes a lot of information <a href="https://www.data.gov">available</a> in many <a href="http://foia.state.gov/Search/Search.aspx">places</a>, you may still seek information that has not already been publicly released. FOIA makes it possible to access records that are not yet publicly available.</p>
 
-            <p><strong>What can I ask for?</strong></p>
+            <h2 id="what">What can I ask for?</h2>
 
             <p>You can file a FOIA request for any “agency record.” This is a broad term that covers things like books, papers, maps, photographs, emails, machine-readable materials, and other documentary materials. You can also specify whether you would like to receive these records in electronic or paper formats as well. </p>
 
-            <p><strong>Is there a special form I have to use to make a FOIA request?</strong></p>
+            <h2 id="form">Is there a special form I have to use to make a FOIA request?</h2>
 
             <p>There is no specific form that must be used to make a request. All you need is to do is write a description of the information you are seeking and comply with any agency-specific requirements. Those requirements are set out in agencies’ FOIA regulations.</p>
 
             <p>Your written description must be specific enough that agency FOIA professionals can understand what you are seeking and properly conduct a search. Information such as time periods, specific names, topics, or key words related to the information you are seeking will help inform the agency.</p>
 
-            <p><strong>How do I make a FOIA request?</strong></p>
+            <h2 id="how">How do I make a FOIA request?</h2>
 
             <p>Requests must be submitted in writing, either electronically or in paper format, and should include a reasonable description of the information you are requesting and the format you prefer.</p>
 
             <p>The FOIA does not require agencies to do research for you, analyze data, answer written questions, or create records in response to your request. That means you may need to do some research before filing a request. An agency’s own website is a good place to start.</p>
 
-            <p><strong>What happens after I make my FOIA request?</strong></p>
+            <h2 id="after">What happens after I make my FOIA request?</h2>
 
             <p>A lot happens behind the scenes after an agency receives your FOIA request. Agencies each have their own specific way of processing a request. The first step is to determine which offices may have responsive records and search for those records. Once an office has located records and provided them back to the FOIA shop, the FOIA team may consult subject matter experts, lawyers, or other agency officials to review them for release. This step may also include redacting any non-public information.</p>
 
             <p>Once the agency has completed this process, any public records will be released to you.</p>
 
-            <p><strong>How long does it take to fulfill my request?</strong></p>
+            <h2 id="when">How long does it take to fulfill my request?</h2>
 
             <p>Response time varies between agencies and also depends on the complexity of the request. The standard time limit established by FOIA is 20 business days, but some requests are more complex and will require more time.</p>
 
@@ -44,7 +56,7 @@
 
             <p>Another option is to agree to a different timetable for processing the request. You can work with the agency’s FOIA Public Liaison or other FOIA contacts to discuss this option. You should always feel free to contact the agency to check on the status of your request. Agencies are required to provide an estimated response date upon request.</p>
 
-            <p><strong>What happens if I’m not satisfied with the response I received?</strong></p>
+            <h2 id="dispute">What happens if I’m not satisfied with the response I received?</h2>
 
             <p>If you disagree with agency’s decision on your request, you can file an appeal by writing to the agency. Agencies review appeals independently and inform you whether your appeal is granted or denied. FOIA also provides for a 20 business day time frame for appeal responses, but, similarly, response times vary based on an agency’s workload and the complexity of your appeal.</p>
 

--- a/foia_hub/templates/learn.html
+++ b/foia_hub/templates/learn.html
@@ -3,55 +3,55 @@
 {% block body %}
 <div class="container">
     <section class="content">
+        <div class="learn">
+            <h2>What is FOIA?</h2>
 
-        <h2>What is FOIA?</h2>
+            <p>Since 1966, the Freedom of Information Act (FOIA) has granted the public the right to request access to any agency records. Under FOIA, agencies are required to disclose any information requested unless it falls under a specific set of <a href="http://www.foia.gov/faq.html#exemptions">exemptions</a> or <a href="http://www.foia.gov/faq.html#exclusions">exclusions</a>.</p>
 
-        <p>Since 1966, the Freedom of Information Act (FOIA) has granted the public the right to request access to any agency records. Under FOIA, agencies are required to disclose any information requested unless it falls under a specific set of <a href="http://www.foia.gov/faq.html#exemptions">exemptions</a> or <a href="http://www.foia.gov/faq.html#exclusions">exclusions</a>.</p>
+            <p>The public's right to request records has served as the backbone for information disclosure in the United States. Records released under FOIA have led to the publication of many important news stories and greater public awareness around government activities.</p>
 
-        <p>The public's right to request records has served as the backbone for information disclosure in the United States. Records released under FOIA have led to the publication of many important news stories and greater public awareness around government activities.</p>
+            <p><strong>Why would I make a FOIA request?</strong></p>
 
-        <p><strong>Why would I make a FOIA request?</strong></p>
+            <p>While the Federal Government makes a lot of information <a href="https://www.data.gov">available</a> in many <a href="http://foia.state.gov/Search/Search.aspx">places</a>, you may still seek information that has not already been publicly released. FOIA makes it possible to access records that are not yet publicly available.</p>
 
-        <p>While the Federal Government makes a lot of information <a href="https://www.data.gov">available</a> in many <a href="http://foia.state.gov/Search/Search.aspx">places</a>, you may still seek information that has not already been publicly released. FOIA makes it possible to access records that are not yet publicly available.</p>
+            <p><strong>What can I ask for?</strong></p>
 
-        <p><strong>What can I ask for?</strong></p>
+            <p>You can file a FOIA request for any “agency record.” This is a broad term that covers things like books, papers, maps, photographs, emails, machine-readable materials, and other documentary materials. You can also specify whether you would like to receive these records in electronic or paper formats as well. </p>
 
-        <p>You can file a FOIA request for any “agency record.” This is a broad term that covers things like books, papers, maps, photographs, emails, machine-readable materials, and other documentary materials. You can also specify whether you would like to receive these records in electronic or paper formats as well. </p>
+            <p><strong>Is there a special form I have to use to make a FOIA request?</strong></p>
 
-        <p><strong>Is there a special form I have to use to make a FOIA request?</strong></p>
+            <p>There is no specific form that must be used to make a request. All you need is to do is write a description of the information you are seeking and comply with any agency-specific requirements. Those requirements are set out in agencies’ FOIA regulations.</p>
 
-        <p>There is no specific form that must be used to make a request. All you need is to do is write a description of the information you are seeking and comply with any agency-specific requirements. Those requirements are set out in agencies’ FOIA regulations.</p>
+            <p>Your written description must be specific enough that agency FOIA professionals can understand what you are seeking and properly conduct a search. Information such as time periods, specific names, topics, or key words related to the information you are seeking will help inform the agency.</p>
 
-        <p>Your written description must be specific enough that agency FOIA professionals can understand what you are seeking and properly conduct a search. Information such as time periods, specific names, topics, or key words related to the information you are seeking will help inform the agency.</p>
+            <p><strong>How do I make a FOIA request?</strong></p>
 
-        <p><strong>How do I make a FOIA request?</strong></p>
+            <p>Requests must be submitted in writing, either electronically or in paper format, and should include a reasonable description of the information you are requesting and the format you prefer.</p>
 
-        <p>Requests must be submitted in writing, either electronically or in paper format, and should include a reasonable description of the information you are requesting and the format you prefer.</p>
+            <p>The FOIA does not require agencies to do research for you, analyze data, answer written questions, or create records in response to your request. That means you may need to do some research before filing a request. An agency’s own website is a good place to start.</p>
 
-        <p>The FOIA does not require agencies to do research for you, analyze data, answer written questions, or create records in response to your request. That means you may need to do some research before filing a request. An agency’s own website is a good place to start.</p>
+            <p><strong>What happens after I make my FOIA request?</strong></p>
 
-        <p><strong>What happens after I make my FOIA request?</strong></p>
+            <p>A lot happens behind the scenes after an agency receives your FOIA request. Agencies each have their own specific way of processing a request. The first step is to determine which offices may have responsive records and search for those records. Once an office has located records and provided them back to the FOIA shop, the FOIA team may consult subject matter experts, lawyers, or other agency officials to review them for release. This step may also include redacting any non-public information.</p>
 
-        <p>A lot happens behind the scenes after an agency receives your FOIA request. Agencies each have their own specific way of processing a request. The first step is to determine which offices may have responsive records and search for those records. Once an office has located records and provided them back to the FOIA shop, the FOIA team may consult subject matter experts, lawyers, or other agency officials to review them for release. This step may also include redacting any non-public information.</p>
+            <p>Once the agency has completed this process, any public records will be released to you.</p>
 
-        <p>Once the agency has completed this process, any public records will be released to you.</p>
+            <p><strong>How long does it take to fulfill my request?</strong></p>
 
-        <p><strong>How long does it take to fulfill my request?</strong></p>
+            <p>Response time varies between agencies and also depends on the complexity of the request. The standard time limit established by FOIA is 20 business days, but some requests are more complex and will require more time.</p>
 
-        <p>Response time varies between agencies and also depends on the complexity of the request. The standard time limit established by FOIA is 20 business days, but some requests are more complex and will require more time.</p>
+            <p>Agencies may also request an extension in “unusual” or “exceptional” circumstances and may pause the request clock to <a href="http://www.justice.gov/oip/foiapost/2008foiapost29.htm">clarify the request</a>. If an agency gets an extension, it will notify you. During this time, the agency will provide you with an opportunity to modify the scope of the request to help improve the response time.</p>
 
-        <p>Agencies may also request an extension in “unusual” or “exceptional” circumstances and may pause the request clock to <a href="http://www.justice.gov/oip/foiapost/2008foiapost29.htm">clarify the request</a>. If an agency gets an extension, it will notify you. During this time, the agency will provide you with an opportunity to modify the scope of the request to help improve the response time.</p>
+            <p>Another option is to agree to a different timetable for processing the request. You can work with the agency’s FOIA Public Liaison or other FOIA contacts to discuss this option. You should always feel free to contact the agency to check on the status of your request. Agencies are required to provide an estimated response date upon request.</p>
 
-        <p>Another option is to agree to a different timetable for processing the request. You can work with the agency’s FOIA Public Liaison or other FOIA contacts to discuss this option. You should always feel free to contact the agency to check on the status of your request. Agencies are required to provide an estimated response date upon request.</p>
+            <p><strong>What happens if I’m not satisfied with the response I received?</strong></p>
 
-        <p><strong>What happens if I’m not satisfied with the response I received?</strong></p>
+            <p>If you disagree with agency’s decision on your request, you can file an appeal by writing to the agency. Agencies review appeals independently and inform you whether your appeal is granted or denied. FOIA also provides for a 20 business day time frame for appeal responses, but, similarly, response times vary based on an agency’s workload and the complexity of your appeal.</p>
 
-        <p>If you disagree with agency’s decision on your request, you can file an appeal by writing to the agency. Agencies review appeals independently and inform you whether your appeal is granted or denied. FOIA also provides for a 20 business day time frame for appeal responses, but, similarly, response times vary based on an agency’s workload and the complexity of your appeal.</p>
+            <p>Sometimes an appeal isn’t the best route. Before filing an appeal, you might want to try contacting the agency that handled the request either through your FOIA contact or the FOIA Public Liaison who is there to help you throughout the FOIA process and help resolve any disputes. Contact information for every agency’s FOIA Public Liaison is listed on <a href="http://www.foia.gov/report-makerequest.html">www.foia.gov</a>.</p>
 
-        <p>Sometimes an appeal isn’t the best route. Before filing an appeal, you might want to try contacting the agency that handled the request either through your FOIA contact or the FOIA Public Liaison who is there to help you throughout the FOIA process and help resolve any disputes. Contact information for every agency’s FOIA Public Liaison is listed on <a href="http://www.foia.gov/report-makerequest.html">www.foia.gov</a>.</p>
-
-        <p>If the appeal process is complete and you are not yet satisfied, you can also seek mediation services from the FOIA Ombudsman’s office, the <a href="https://ogis.archives.gov/">Office of Government Information Services</a> at the National Archives and Records Administration.</p>
-
+            <p>If the appeal process is complete and you are not yet satisfied, you can also seek mediation services from the FOIA Ombudsman’s office, the <a href="https://ogis.archives.gov/">Office of Government Information Services</a> at the National Archives and Records Administration.</p>
+        </div>
     </section>
 </div>
 {% endblock %}


### PR DESCRIPTION
# Redesign

*This pull request is dependent on and includes #422*

Implements the agency landing page (#396), search results page (#399 #398), and some work on about and learn (#397).

# Views

## Agency landing desktop
![screen shot 2015-01-21 at 6 05 55 pm](https://cloud.githubusercontent.com/assets/582918/5847232/fbea8b18-a198-11e4-9fb8-ec99e4969cdf.png)

## Agency landing mobile
![screen shot 2015-01-21 at 6 09 22 pm](https://cloud.githubusercontent.com/assets/582918/5847236/000865e4-a199-11e4-9f26-43e51dbb8c24.png)

## Search results desktop
![screen shot 2015-01-21 at 6 05 55 pm](https://cloud.githubusercontent.com/assets/582918/5847244/0bb8d2ca-a199-11e4-857e-adc5561ecd31.png)

## Search results mobile
![screen shot 2015-01-21 at 6 09 22 pm](https://cloud.githubusercontent.com/assets/582918/5847245/10f3deb0-a199-11e4-8dc7-0dccc797bc3f.png)

# Notes

Definitely some small visual fixes needed, largely around whitespace.