### PR TITLE
template change to accommodate addresses

### DIFF
--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -81,7 +81,9 @@
               {% for line in profile.address_lines %}
                 {{ line }}<br/>
               {% endfor %}
-              {{ profile.street }}<br/>
+              {% if profile.street %}
+                {{ profile.street }}<br/>
+              {% endif %}
               {{ profile.city }}, {{ profile.state }} {{ profile.zip_code }}
             </p>
           </div>


### PR DESCRIPTION
Connected to 18F/foia/pull/102
Some address don't have a street name this should prevent the gap between the address_lines and city, state, and zip fields. 
![screen shot 2015-01-26 at 3 18 06 pm](https://cloud.githubusercontent.com/assets/4596845/5908847/0ed4ce62-a579-11e4-99be-197753c15b51.png)
