### PR TITLE
Add keyword search. Make search API work.

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -54,7 +54,7 @@ The information returned for each entity is like the following::
     }
 
 """"""""""""""""""""""""""""""
-GET /api/agency/query='privacy'
+GET /api/agency/?query=privacy
 """"""""""""""""""""""""""""""
 
 To search agencies, you can provide query parameter called 'query'. This will

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -53,6 +53,15 @@ The information returned for each entity is like the following::
       ]
     }
 
+""""""""""""""""""""""""""""""
+GET /api/agency/query='privacy'
+""""""""""""""""""""""""""""""
+
+To search agencies, you can provide query parameter called 'query'. This will
+initiate a search for your query across the following Agency fields: name,
+abbreviation, slug, keywords, description.
+
+
 """"""""""""""""""""""""""""""""""
 GET /api/agency/{{slug}}
 """"""""""""""""""""""""""""""""""

--- a/foia_hub/api.py
+++ b/foia_hub/api.py
@@ -128,11 +128,17 @@ class AgencyResource(DjangoResource):
         query parameter. It doesn't provide every field for every object,
         instead limiting the output to useful fields. To see the detail for
         each object, use the detail endpoint. """
+
+        # Use request 'query' parameter if it exists
+        if self.request and 'query' in self.request.GET:
+            q = self.request.GET.get('query', None)
+
         if q:
             agencies = Agency.objects.filter(
                 Q(abbreviation__icontains=q) |
                 Q(name__icontains=q) |
                 Q(slug__icontains=q) |
+                Q(keywords__icontains=q) |
                 Q(description__icontains=q)
             )
         else:

--- a/foia_hub/fixtures/agencies_test.json
+++ b/foia_hub/fixtures/agencies_test.json
@@ -46,7 +46,7 @@
             "description": "The historic mission of the Department of Commerce is \"to foster, promote, and develop the foreign and domestic commerce\" of the United States. This has evolved, as a result of legislative and administrative additions, to encompass broadly the responsibility to foster, serve, and promote the Nation's economic development and technological advancement.",
             "emails": ["foia@doc.gov"],
             "fax": null,
-            "keywords": null,
+            "keywords": ["business", "industry", "forests", "petroleum"],
             "name": "Department of Commerce",
             "office_url": null,
             "parent": null,

--- a/foia_hub/tests/test_api.py
+++ b/foia_hub/tests/test_api.py
@@ -96,6 +96,15 @@ class AgencyAPITests(TestCase):
             'us-patent-and-trademark-office'],
             slugs)
 
+    def test_list_query(self):
+        c = Client()
+        response = c.get('/api/agency/?query=industry')
+        self.assertEqual(200, response.status_code)
+        content = helpers.json_from(response)
+        self.assertEqual(len(content['objects']), 1)
+        self.assertEqual(
+            content['objects'][0]['slug'], 'department-of-commerce')
+
     def test_detail(self):
         """ Check the detail view for an agency."""
 


### PR DESCRIPTION
Keywords were not being searched in the backend search that we have. They were in the autocomplete that we had previously, but that's replaced with a simpler autocomplete. 

This adds the keyword search back in. 

It also makes the API for the list of agencies take a query parameter. 