### PR TITLE
Link to production dashboard

### DIFF
--- a/foia_hub/templates/about.html
+++ b/foia_hub/templates/about.html
@@ -68,7 +68,7 @@
 
             <h2>More about this project</h2>
 
-            <p>Our work is one of a number of <a href="http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf">commitments</a> towards modernizing the Freedom of Information Act. We are currently in the <a href="https://18f.github.io/dashboard/stages/">alpha</a> stage of development. Developers can find additional technical information <a href="/developers">here.</a></p>
+            <p>Our work is one of a number of <a href="http://www.whitehouse.gov/sites/default/files/docs/us_national_action_plan_6p.pdf">commitments</a> towards modernizing the Freedom of Information Act. We are currently in the <a href="https://18f.gsa.gov/dashboard/stages/">alpha</a> stage of development. Developers can find additional technical information <a href="/developers">here.</a></p>
 
             <hr />
 


### PR DESCRIPTION
We link to the dashboard on the `/about` page. This switches the link to the official `18f.gsa.gov` URL.