### PR TITLE
Updates while moving foia.18f.us to use new Heroku-style env settings

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: waitress-serve --port=$PORT foia_hub.wsgi:application
+web: waitress-serve --port=$VCAP_APP_PORT foia_hub.wsgi:application

--- a/cloudfoundry.md
+++ b/cloudfoundry.md
@@ -92,6 +92,20 @@ git push heroku cloudfoundry:master
 heroku run python manage.py migrate
 ```
 
-* Load the data.
+## Moving AWS to use Heroku-style deployment
 
-```bash
+* Moved some old settings file into `shared/old`.
+* Made a new `shared/log` dir and restarted nginx to kick off nginx log files again.
+* Updated fabfile with a first pass at new approach.
+* Renamed `env` to `foia-env`, since `env` is a system command.
+* Removed `links` method in `fabfile.py`, since we don't need unversioned files anymore.
+* **Important**: the `$PYTHONPATH` variable should _not_ be set. If it is set, it interferes in non-obvious ways to make the server not see env variables and not start.
+* Sourced environment variables for the `migrate` step in the fabfile.
+* Temporarily add `$PORT` to the env file as well, since the `Procfile` uses `$PORT`.
+* Change the `start` command to use `nohup foreman start &`.
+* Change the `stop` command to just `killall waitress-server`
+
+Status:
+
+* `fab deploy` will stay hanging, but successfully daemonize the app.
+* The webhook is down.


### PR DESCRIPTION
This renames an environment variable, and reworks our Fabric file. The site is now running again at `foia.18f.us`, pointed to the production Postgresql database.

Two limitations remain:

* The auto-deploy webhook is not functional. I've disabled the deploy webhook in this repository's settings.
* Running `fab deploy` will successfully deploy, start, and daemonize the application server -- however, the janky approach to daemonization, `nohup`, causes the `fab` command to just hang. You will need to forcibly exit that process.

These limitations come from the fact that neither `waitress` nor `foreman` is designed, out of the box, to be daemonized using traditional unix tools (there's no `--daemonize` flag for either of them, the way that `gunicorn` has).

The way to proceed would, I think, be to use one of [Foreman's export formats](http://ddollar.github.io/foreman/) to create a systemd or upstart or supervisord bootstrap thing. Some of those would require `sudo`.

But in any case, I suggest that it's not worth spending a lot of time addressing the above limitations, as it is a temporary situation while we're barreling forward into Cloud Foundry.