### PR TITLE
Custom domain route in Cloud Foundry

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,4 +1,5 @@
 .env
+/staticfiles
 
 *.log
 *.db

--- a/.cfignore
+++ b/.cfignore
@@ -1,6 +1,6 @@
-debug.log
-npm-debug.log
+.env
 
+*.log
 *.db
 
 node_modules
@@ -16,8 +16,6 @@ node_modules
 */static/sass/bourbon
 */static/sass/neat
 .webassets-cache
-
-local_settings.py
 
 /todo.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+/staticfiles
 
 *.log
 *.db

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: waitress-serve --port=$PORT foia_hub.wsgi:application
+web: waitress-serve --port=$VCAP_APP_PORT foia_hub.wsgi:application

--- a/cloudfoundry.md
+++ b/cloudfoundry.md
@@ -122,34 +122,20 @@ Better instructions TBD!
 ## Cloud Foundry time
 
 * Change `Procfile` to use `$VCAP_APP_PORT` instead of `$PORT`.
-* Create the Postgresql service:
 
-```bash
-cf create-service postgresql default foia-db
-```
-
-* Bind the postgresql service to the app:
+* Set the necessary environment variables:
 
 ```
-cf bind-service foia-testing foia-db
+cf set-env foia DATABASE_URL [value]
+cf set-env foia FOIA_ANALYTICS_ID [value]
+cf set-env foia FOIA_SECRET_SESSION_KEY [value]
+cf set-env foia DJANGO_SETTINGS_MODULE foia_hub.settings.dev
 ```
 
-* Grab the database URL from the env. It's in `VCAP_SERVICES.postgresql-9.3.credentials.uri`.
+* Moved the runtime down from `3.4.2` to `3.4.0`, as that's what 18F's CF currently supports.
 
-```
-cf env foia-testing
-```
+* Renamed app from `foia-testing` to `foia`.
 
-* Set the `DATABASE_URL` to that URL.
+* Ignored the `staticfiles/` directory.
 
-```
-cf set-env foia-testing [url]
-```
-
-* Set the remaining environment variables, one by one.
-
-```
-cf set-env foia-testing FOIA_ANALYTICS_ID [value]
-cf set-env foia-testing FOIA_SECRET_SESSION_KEY [value]
-cf set-env foia-testing DJANGO_SETTINGS_MODULE foia_hub.settings.dev
-```
+* Re-synced the `.cfignore` and `.gitignore`.

--- a/cloudfoundry.md
+++ b/cloudfoundry.md
@@ -100,3 +100,38 @@ Right now, load it *locally* from your laptop, with a connection string pointed 
 ./manage.py load_agency_contacts /path/to/foia/contacts/data
 
 Better instructions TBD!
+
+## Cloud Foundry time
+
+* Change `Procfile` to use `$VCAP_APP_PORT` instead of `$PORT`.
+* Create the Postgresql service:
+
+```bash
+cf create-service postgresql default foia-db
+```
+
+* Bind the postgresql service to the app:
+
+```
+cf bind-service foia-testing foia-db
+```
+
+* Grab the database URL from the env. It's in `VCAP_SERVICES.postgresql-9.3.credentials.uri`.
+
+```
+cf env foia-testing
+```
+
+* Set the `DATABASE_URL` to that URL.
+
+```
+cf set-env foia-testing [url]
+```
+
+* Set the remaining environment variables, one by one.
+
+```
+cf set-env foia-testing FOIA_ANALYTICS_ID [value]
+cf set-env foia-testing FOIA_SECRET_SESSION_KEY [value]
+cf set-env foia-testing DJANGO_SETTINGS_MODULE foia_hub.settings.dev
+```

--- a/cloudfoundry.md
+++ b/cloudfoundry.md
@@ -139,3 +139,13 @@ cf set-env foia DJANGO_SETTINGS_MODULE foia_hub.settings.dev
 * Ignored the `staticfiles/` directory.
 
 * Re-synced the `.cfignore` and `.gitignore`.
+
+## Custom domain
+
+* Map a route from our app to a custom domain.
+
+```bash
+cf map-route foia open.foia.gov
+```
+
+* Setting the host value in `/etc/hosts` locally for `open.foia.gov` to the IP address used by `cf.18f.us` should then cause `http://open.foia.gov` to show the deployed app in your browser.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+# all applications use these settings and services
+memory: 1G
+instances: 1
+applications:
+- name: foia-testing
+  path: .
+  timeout: 180

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,6 @@
 memory: 1G
 instances: 1
 applications:
-- name: foia-testing
+- name: foia
   path: .
   timeout: 180

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.2
+python-3.4.0


### PR DESCRIPTION
This adds the instructions for setting a custom domain that the app will respond to in Cloud Foundry.

This is **downstream** of #568, which should be merged first.

Fixes #546.