### PR TITLE
Revert to gunicorn for fabric based deploys for now

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -67,27 +67,23 @@ def cleanup():
 
 def start():
     """
-    Foreman start, Heroku-style:
-    * with the virtualenv enabled.
-    * with the environment variables for the production server sourced.
-    * run the command in our versioned Procfile.
+    Gunicorn start.
     """
 
     run(
         (
             "workon %s && source %s && " +
-            "cd %s && "
-            "nohup foreman start &"
-        ) % (virtualenv, env, current_path), pty=False
+            "cd %s && " +
+            "gunicorn -c %s/config.py %s"
+        ) % (virtualenv, env, current_path, shared_path, wsgi), pty=False
     )
 
 # config.py is expected to point the .pid to the shared/ dir
 def stop():
-    run("killall waitress-serve")
+    run("kill `cat %s/gunicorn.pid`" % shared_path)
 
 def restart():
-    stop()
-    start()
+    run("kill -HUP `cat %s/gunicorn.pid`" % shared_path)
 
 def deploy():
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ dj-static==0.0.6
 dj-database-url==0.3.0
 
 django-localflavor
+
+# temporary, while we maintain an EC2 instance
+gunicorn


### PR DESCRIPTION
Hopefully it'll be moot soon enough, but this will stabilize the EC2-based staging site for now.

I've already used this to deploy to the staging site, so it is running with gunicorn right now. The webhook remains disabled, and I suggest we keep it that way for the time being.