### PR TITLE
Only import newrelic, if you intend to use it

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,3 +1,5 @@
+# Copy this file to .env so that you can use tools like foreman or autoenv to
+# manage these environment variables. 
 
 # Which environment? (defaults to development)
 DJANGO_SETTINGS_MODULE=foia_hub.settings.dev
@@ -11,14 +13,14 @@ FOIA_SECRET_SESSION_KEY="CHANGE THIS"
 # Replace with a Google Analytics ID in production
 FOIA_ANALYTICS_ID=""
 
-# Enable the app's own webform. (Not recommended.)
+# Enable the app's own webform. (Not recommended)
 # FOIA_SHOW_WEBFORM=true
 
 # To use a sqlite3 DB:
 DATABASE_URL="sqlite:///./foia.db"
 
-# To use Postgres:
-# DATABASE_URL=postgres://username:password@host:5432/whatever
+# To use PostgreSQL:
+# DATABASE_URL="postgres://username:password@host:5432/databasename"
 
-# New Relic Key and Toggle, if there is a key new relic will run
+# New Relic Key and Toggle, if there is a key New Relic will run
 # NEW_RELIC_LICENSE_KEY=`licence key`

--- a/env.example
+++ b/env.example
@@ -13,7 +13,7 @@ FOIA_SECRET_SESSION_KEY="CHANGE THIS"
 # Replace with a Google Analytics ID in production
 FOIA_ANALYTICS_ID=""
 
-# Enable the app's own webform. (Not recommended)
+# Enable the app's own webform. (Not recommended.)
 # FOIA_SHOW_WEBFORM=true
 
 # To use a sqlite3 DB:

--- a/env.example
+++ b/env.example
@@ -23,4 +23,7 @@ DATABASE_URL="sqlite:///./foia.db"
 # DATABASE_URL="postgres://username:password@host:5432/databasename"
 
 # New Relic Key and Toggle, if there is a key New Relic will run
+# You'll need to install the New Relic agent available here: 
+# https://docs.newrelic.com/docs/agents/python-agent/getting-started/python-agent-quick-start
+
 # NEW_RELIC_LICENSE_KEY=`licence key`

--- a/foia_hub/wsgi.py
+++ b/foia_hub/wsgi.py
@@ -6,7 +6,6 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
-import newrelic.agent
 import os
 from django.core.wsgi import get_wsgi_application
 from dj_static import Cling
@@ -14,6 +13,7 @@ from dj_static import Cling
 from foia_hub.settings.base import BASE_DIR
 
 if os.getenv("NEW_RELIC_LICENSE_KEY"):
+    import newrelic.agent
     newrelic.agent.initialize(os.path.join(
         BASE_DIR, 'newrelic.ini'))
 


### PR DESCRIPTION
A previous wsgi.py change imported the newrelic agent whether you planned to use it or not. Let's not assume everyone is going to need New Relic or want to install it. 

Only import if you've provided a LICENSE_KEY (a strong indication that you want to use new relic)