### PR TITLE
Re-working how reading rooms are stored.

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,3 +1,5 @@
+# Copy this file to .env so that you can use tools like foreman or autoenv to
+# manage these environment variables. 
 
 # Which environment? (defaults to development)
 DJANGO_SETTINGS_MODULE=foia_hub.settings.dev
@@ -11,14 +13,14 @@ FOIA_SECRET_SESSION_KEY="CHANGE THIS"
 # Replace with a Google Analytics ID in production
 FOIA_ANALYTICS_ID=""
 
-# Enable the app's own webform. (Not recommended.)
+# Enable the app's own webform. (Not recommended)
 # FOIA_SHOW_WEBFORM=true
 
 # To use a sqlite3 DB:
 DATABASE_URL="sqlite:///./foia.db"
 
-# To use Postgres:
-# DATABASE_URL=postgres://username:password@host:5432/whatever
+# To use PostgreSQL:
+# DATABASE_URL="postgres://username:password@host:5432/databasename"
 
-# New Relic Key and Toggle, if there is a key new relic will run
+# New Relic Key and Toggle, if there is a key New Relic will run
 # NEW_RELIC_LICENSE_KEY=`licence key`

--- a/env.example
+++ b/env.example
@@ -13,7 +13,7 @@ FOIA_SECRET_SESSION_KEY="CHANGE THIS"
 # Replace with a Google Analytics ID in production
 FOIA_ANALYTICS_ID=""
 
-# Enable the app's own webform. (Not recommended)
+# Enable the app's own webform. (Not recommended.)
 # FOIA_SHOW_WEBFORM=true
 
 # To use a sqlite3 DB:

--- a/env.example
+++ b/env.example
@@ -23,4 +23,7 @@ DATABASE_URL="sqlite:///./foia.db"
 # DATABASE_URL="postgres://username:password@host:5432/databasename"
 
 # New Relic Key and Toggle, if there is a key New Relic will run
+# You'll need to install the New Relic agent available here: 
+# https://docs.newrelic.com/docs/agents/python-agent/getting-started/python-agent-quick-start
+
 # NEW_RELIC_LICENSE_KEY=`licence key`

--- a/foia_hub/fixtures/agencies_test.json
+++ b/foia_hub/fixtures/agencies_test.json
@@ -30,14 +30,6 @@
     },
     {
         "fields": {
-            "link_text": "The Electronic Reading Room",
-            "url": "http://www.doc.gov/err/"
-        },
-        "model": "foia_hub.readingroomurls",
-        "pk": 175
-    },
-    {
-        "fields": {
             "TTY_phone": null,
             "abbreviation": "DOC",
             "address_lines": [],
@@ -55,7 +47,6 @@
             "public_liaison_email": null,
             "public_liaison_name": null,
             "public_liaison_phone": null,
-            "reading_room_urls": [175],
             "request_form_url": null,
             "slug": "department-of-commerce",
             "state": "",
@@ -65,6 +56,16 @@
         },
         "model": "foia_hub.agency",
         "pk": 17
+    },
+    {
+        "fields": {
+            "link_text": "The Electronic Reading Room",
+            "url": "http://www.doc.gov/err/", 
+            "object_id": 17,
+            "content_type": ["foia_hub", "agency"]
+        },
+        "model": "foia_hub.readingroomurls",
+        "pk": 175
     },
     {
         "fields": {

--- a/foia_hub/fixtures/offices_test.json
+++ b/foia_hub/fixtures/offices_test.json
@@ -26,14 +26,6 @@
     },
     {
         "fields": {
-            "link_text": "The Electronic Reading Room",
-            "url": "http://www.usmint.gov/FOIA/?action=room"
-        },
-        "model": "foia_hub.readingroomurls",
-        "pk": 157
-    },
-    {
-        "fields": {
             "TTY_phone": null,
             "address_lines": [],
             "agency": 15,
@@ -47,7 +39,6 @@
             "public_liaison_email": null,
             "public_liaison_name": null,
             "public_liaison_phone": null,
-            "reading_room_urls": [157],
             "request_form_url": null,
             "slug": "department-of-homeland-security--federal-emergency-management-agency",
             "state": "",
@@ -57,5 +48,15 @@
         },
         "model": "foia_hub.office",
         "pk": 20
+    },
+    {
+        "fields": {
+            "link_text": "The Electronic Reading Room",
+            "url": "http://www.usmint.gov/FOIA/?action=room",
+            "object_id": 20,
+            "content_type": ["foia_hub", "office"]
+        },
+        "model": "foia_hub.readingroomurls",
+        "pk": 157
     }
 ]

--- a/foia_hub/migrations/0019_auto_20150301_1941.py
+++ b/foia_hub/migrations/0019_auto_20150301_1941.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/foia_hub/migrations/0019_auto_20150301_1941.py
+++ b/foia_hub/migrations/0019_auto_20150301_1941.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('foia_hub', '0018_delete_office_dups'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='agency',
+            name='reading_room_urls',
+        ),
+        migrations.RemoveField(
+            model_name='office',
+            name='reading_room_urls',
+        ),
+    ]

--- a/foia_hub/migrations/0020_delete_readingroomurls.py
+++ b/foia_hub/migrations/0020_delete_readingroomurls.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/foia_hub/migrations/0020_delete_readingroomurls.py
+++ b/foia_hub/migrations/0020_delete_readingroomurls.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('foia_hub', '0019_auto_20150301_1941'),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name='ReadingRoomUrls',
+        ),
+    ]

--- a/foia_hub/migrations/0021_readingroomurls.py
+++ b/foia_hub/migrations/0021_readingroomurls.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('foia_hub', '0020_delete_readingroomurls'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ReadingRoomUrls',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('link_text', models.CharField(max_length=512, help_text='This is the text associated with the reading room URL. ')),
+                ('url', models.URLField(null=True, help_text="The URL to an agency's reading room.")),
+                ('agency', models.ForeignKey(to='foia_hub.Agency')),
+                ('office', models.ForeignKey(to='foia_hub.Office', blank=True, null=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/foia_hub/migrations/0022_auto_20150301_2049.py
+++ b/foia_hub/migrations/0022_auto_20150301_2049.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0001_initial'),
+        ('foia_hub', '0021_readingroomurls'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='readingroomurls',
+            name='agency',
+        ),
+        migrations.RemoveField(
+            model_name='readingroomurls',
+            name='office',
+        ),
+        migrations.AddField(
+            model_name='readingroomurls',
+            name='content_type',
+            field=models.ForeignKey(default=0, to='contenttypes.ContentType'),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='readingroomurls',
+            name='object_id',
+            field=models.PositiveIntegerField(default=0),
+            preserve_default=False,
+        ),
+    ]

--- a/foia_hub/models.py
+++ b/foia_hub/models.py
@@ -2,6 +2,9 @@ import logging
 
 from django.db import models
 from django.utils.text import slugify
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.models import ContentType
 
 from jsonfield import JSONField
 from localflavor.us.models import PhoneNumberField, USPostalCodeField
@@ -37,6 +40,27 @@ class USAddress(models.Model):
         abstract = True
 
 
+class ReadingRoomUrls(models.Model):
+    """ Reading rooms are where agencies and offices put their disclosed
+    documents. """
+
+    object_id = models.PositiveIntegerField()
+    content_type = models.ForeignKey(ContentType)
+    content_object = GenericForeignKey('content_type', 'object_id')
+    #agency = models.ForeignKey(Agency)
+    #office = models.ForeignKey(Office, null=True, blank=True)
+    link_text = models.CharField(
+        max_length=512,
+        help_text="This is the text associated with the reading room URL. ")
+    url = models.URLField(
+        null=True, help_text="The URL to an agency's reading room.")
+
+
+    def __unicode__(self):
+        return '%s %s' % (self.link_text, self.url)
+
+    def __str__(self):
+        return self.__unicode__()
 
 
 class Contactable(USAddress):
@@ -56,6 +80,7 @@ class Contactable(USAddress):
 
     #reading_room_urls = models.ManyToManyField(
     #    ReadingRoomUrls, related_name="%(app_label)s_%(class)s_related")
+    reading_room_urls = GenericRelation(ReadingRoomUrls)
 
     request_form_url = models.URLField(
         null=True,
@@ -142,24 +167,6 @@ class Office(Contactable):
         """ Helper method for slugifying office names."""
         return slugify(text)[:50]
 
-class ReadingRoomUrls(models.Model):
-    """ Reading rooms are where agencies and offices put their disclosed
-    documents. """
-
-    agency = models.ForeignKey(Agency)
-    office = models.ForeignKey(Office, null=True, blank=True)
-    link_text = models.CharField(
-        max_length=512,
-        help_text="This is the text associated with the reading room URL. ")
-    url = models.URLField(
-        null=True, help_text="The URL to an agency's reading room.")
-
-
-    def __unicode__(self):
-        return '%s %s' % (self.link_text, self.url)
-
-    def __str__(self):
-        return self.__unicode__()
 
 class Stats(models.Model):
     """

--- a/foia_hub/models.py
+++ b/foia_hub/models.py
@@ -47,8 +47,6 @@ class ReadingRoomUrls(models.Model):
     object_id = models.PositiveIntegerField()
     content_type = models.ForeignKey(ContentType)
     content_object = GenericForeignKey('content_type', 'object_id')
-    #agency = models.ForeignKey(Agency)
-    #office = models.ForeignKey(Office, null=True, blank=True)
     link_text = models.CharField(
         max_length=512,
         help_text="This is the text associated with the reading room URL. ")
@@ -78,8 +76,6 @@ class Contactable(USAddress):
         null=True,
         help_text='A FOIA specific URL for the office or the agency.')
 
-    #reading_room_urls = models.ManyToManyField(
-    #    ReadingRoomUrls, related_name="%(app_label)s_%(class)s_related")
     reading_room_urls = GenericRelation(ReadingRoomUrls)
 
     request_form_url = models.URLField(

--- a/foia_hub/models.py
+++ b/foia_hub/models.py
@@ -37,24 +37,6 @@ class USAddress(models.Model):
         abstract = True
 
 
-class ReadingRoomUrls(models.Model):
-    """ Reading rooms are where agencies and offices put their disclosed
-    documents. """
-
-    link_text = models.CharField(
-        max_length=512,
-        help_text="This is the text associated with the reading room URL. ")
-    url = models.URLField(
-        null=True, help_text="The URL to an agency's reading room.")
-
-    def __unicode__(self):
-        return '%s %s' % (self.link_text, self.url)
-
-    def __str__(self):
-        return self.__unicode__()
-
-    class Meta:
-        unique_together = (("link_text", "url"),)
 
 
 class Contactable(USAddress):
@@ -72,8 +54,8 @@ class Contactable(USAddress):
         null=True,
         help_text='A FOIA specific URL for the office or the agency.')
 
-    reading_room_urls = models.ManyToManyField(
-        ReadingRoomUrls, related_name="%(app_label)s_%(class)s_related")
+    #reading_room_urls = models.ManyToManyField(
+    #    ReadingRoomUrls, related_name="%(app_label)s_%(class)s_related")
 
     request_form_url = models.URLField(
         null=True,
@@ -160,6 +142,24 @@ class Office(Contactable):
         """ Helper method for slugifying office names."""
         return slugify(text)[:50]
 
+class ReadingRoomUrls(models.Model):
+    """ Reading rooms are where agencies and offices put their disclosed
+    documents. """
+
+    agency = models.ForeignKey(Agency)
+    office = models.ForeignKey(Office, null=True, blank=True)
+    link_text = models.CharField(
+        max_length=512,
+        help_text="This is the text associated with the reading room URL. ")
+    url = models.URLField(
+        null=True, help_text="The URL to an agency's reading room.")
+
+
+    def __unicode__(self):
+        return '%s %s' % (self.link_text, self.url)
+
+    def __str__(self):
+        return self.__unicode__()
 
 class Stats(models.Model):
     """

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -113,19 +113,19 @@ def add_request_time_statistics(data, agency, office=None):
 
 def add_reading_rooms(contactable, data):
 
-    # delete old data
-    contactable.reading_room_urls.all().delete()
-
     for link_text, url in data.get('reading_rooms', []):
-        existing_room = ReadingRoomUrls.objects.filter(
-            link_text=link_text, url=url)
-        existing_room = list(existing_room)
-        if len(existing_room) > 0:
-            contactable.reading_room_urls.add(*existing_room)
-        else:
-            r = ReadingRoomUrls(link_text=link_text, url=url)
-            r.save()
-            contactable.reading_room_urls.add(r)
+        rru = ReadingRoomUrls(
+            content_object=contactable, link_text=link_text, url=url)
+        rru.save()
+        #existing_room = ReadingRoomUrls.objects.filter(
+        #    link_text=link_text, url=url)
+        #existing_room = list(existing_room)
+        #if len(existing_room) > 0:
+        #    contactable.reading_room_urls.add(*existing_room)
+        #else:
+        #    r = ReadingRoomUrls(link_text=link_text, url=url)
+        #    r.save()
+        #    contactable.reading_room_urls.add(r)
 
 
 def build_abbreviation(agency_name):

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -117,16 +117,6 @@ def add_reading_rooms(contactable, data):
         rru = ReadingRoomUrls(
             content_object=contactable, link_text=link_text, url=url)
         rru.save()
-        #existing_room = ReadingRoomUrls.objects.filter(
-        #    link_text=link_text, url=url)
-        #existing_room = list(existing_room)
-        #if len(existing_room) > 0:
-        #    contactable.reading_room_urls.add(*existing_room)
-        #else:
-        #    r = ReadingRoomUrls(link_text=link_text, url=url)
-        #    r.save()
-        #    contactable.reading_room_urls.add(r)
-
 
 def build_abbreviation(agency_name):
     """ Given an agency name, guess at an abbrevation. """

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -79,7 +79,7 @@ def contactable_fields(agency, office_dict):
     agency.city = address.get('city')
     agency.street = address.get('street')
     agency.address_lines = address.get('address_lines', [])
-    add_reading_rooms(agency, office_dict)
+    update_reading_rooms(agency, office_dict)
 
 
 def add_request_time_statistics(data, agency, office=None):
@@ -111,7 +111,10 @@ def add_request_time_statistics(data, agency, office=None):
                     stat.save()
 
 
-def add_reading_rooms(contactable, data):
+def update_reading_rooms(contactable, data):
+    """ This ensures that the reading rooms indicated in `data` are added to
+    the contactable (agency, office). If the contactable already has reading
+    rooms, those are deleted first. """
 
     # Delete all existing reading rooms, because we'll re-add them.
     contactable.reading_room_urls.all().delete()

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -112,6 +112,9 @@ def add_request_time_statistics(data, agency, office=None):
 
 
 def add_reading_rooms(contactable, data):
+    
+    # Delete all existing reading rooms, because we'll re-add them. 
+    contactable.reading_room_urls.all().delete()
 
     for link_text, url in data.get('reading_rooms', []):
         rru = ReadingRoomUrls(

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -112,14 +112,15 @@ def add_request_time_statistics(data, agency, office=None):
 
 
 def add_reading_rooms(contactable, data):
-    
-    # Delete all existing reading rooms, because we'll re-add them. 
+
+    # Delete all existing reading rooms, because we'll re-add them.
     contactable.reading_room_urls.all().delete()
 
     for link_text, url in data.get('reading_rooms', []):
         rru = ReadingRoomUrls(
             content_object=contactable, link_text=link_text, url=url)
         rru.save()
+
 
 def build_abbreviation(agency_name):
     """ Given an agency name, guess at an abbrevation. """

--- a/foia_hub/tests/test_api.py
+++ b/foia_hub/tests/test_api.py
@@ -57,14 +57,18 @@ class PreparerTests(TestCase):
     def test_reading_room_preparer(self):
         """ Ensure reading room urls are serialized correctly. """
 
-        rone = ReadingRoomUrls(link_text='Url One', url='http://urlone.gov')
-        rone.save()
-        rtwo = ReadingRoomUrls(link_text='Url Two', url='http://urltwo.gov')
-        rtwo.save()
-
         census = Office.objects.get(
             slug='department-of-commerce--census-bureau')
-        census.reading_room_urls.add(rone, rtwo)
+        #census.reading_room_urls.add(rone, rtwo)
+
+        rone = ReadingRoomUrls(
+            content_object=census, link_text='Url One', url='http://urlone.gov')
+        rone.save()
+        rtwo = ReadingRoomUrls(
+            content_object=census, link_text='Url Two', url='http://urltwo.gov')
+        rtwo.save()
+
+        
         data = foia_libraries_preparer(census)
 
         serialized_rooms = {'foia_libraries': [

--- a/foia_hub/tests/test_api.py
+++ b/foia_hub/tests/test_api.py
@@ -59,7 +59,6 @@ class PreparerTests(TestCase):
 
         census = Office.objects.get(
             slug='department-of-commerce--census-bureau')
-        #census.reading_room_urls.add(rone, rtwo)
 
         rone = ReadingRoomUrls(
             content_object=census, link_text='Url One', url='http://urlone.gov')
@@ -68,7 +67,6 @@ class PreparerTests(TestCase):
             content_object=census, link_text='Url Two', url='http://urltwo.gov')
         rtwo.save()
 
-        
         data = foia_libraries_preparer(census)
 
         serialized_rooms = {'foia_libraries': [

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -147,7 +147,7 @@ class LoaderTest(TestCase):
 
 class LoadingTest(TestCase):
 
-    fixtures = ['agencies_test.json']
+    fixtures = ['agencies_test.json', 'offices_test.json']
 
     def test_add_reading_rooms(self):
         """ Test if reading rooms are added properly """
@@ -176,6 +176,35 @@ class LoadingTest(TestCase):
         self.assertEqual(
             'http://agency.gov/pre-2000/rooms',
             dhs.reading_room_urls.all()[1].url)
+
+    def test_add_delete_reading_rooms(self):
+        """ Add a reading room. Then, remove a reading room (by omission)
+        during a subsequent load. The reading rooms in the database should
+        reflect these changes (the removed reading room should not be there.
+        """
+
+        census = Office.objects.get(
+            slug='department-of-commerce--census-bureau')
+        all_rooms = census.reading_room_urls.all().count()
+        self.assertEqual(0, all_rooms)
+
+        data = {
+            'reading_rooms': [
+                ['Url One', 'http://urlone.gov'],
+                ['Url Two', 'http://urltwo.gov']]}
+        add_reading_rooms(census, data)
+        all_rooms = census.reading_room_urls.all()
+        self.assertEqual(2, len(all_rooms))
+
+        data = {
+            'reading_rooms': [
+                ['Url One', 'http://urlone.gov'],
+                ['Url Three', 'http://urlthree.gov']]}
+        add_reading_rooms(census, data)
+        rr_count = census.reading_room_urls.all().count()
+        self.assertEqual(2, rr_count)
+
+
 
     def test_add_stats(self):
         """

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -177,16 +177,6 @@ class LoadingTest(TestCase):
             'http://agency.gov/pre-2000/rooms',
             dhs.reading_room_urls.all()[1].url)
 
-        # Add reading rooms again with altered data
-        reading_room_data = {
-            'reading_rooms': [
-                ['Electronic Reading Room', 'http://agency.gov/err/'],
-                ['Pre-2000 Reading Room', 'http://agency.gov/']]
-        }
-        add_reading_rooms(agency, reading_room_data)
-        dhs = Agency.objects.get(slug='department-of-homeland-security')
-        self.assertEqual(2, len(dhs.reading_room_urls.all()))
-
     def test_add_stats(self):
         """
         Confirms all latest records are loaded, no empty records

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 
 from foia_hub.models import Agency, Office
 from foia_hub.scripts.load_agency_contacts import (
-    load_data, add_reading_rooms, add_request_time_statistics,
+    load_data, update_reading_rooms, add_request_time_statistics,
     extract_tty_phone, extract_non_tty_phone, build_abbreviation)
 
 example_office1 = {
@@ -149,7 +149,7 @@ class LoadingTest(TestCase):
 
     fixtures = ['agencies_test.json', 'offices_test.json']
 
-    def test_add_reading_rooms(self):
+    def test_update_reading_rooms(self):
         """ Test if reading rooms are added properly """
 
         reading_room_data = {
@@ -158,7 +158,7 @@ class LoadingTest(TestCase):
                 ['Pre-2000 Reading Room', 'http://agency.gov/pre-2000/rooms']]
         }
         agency = Agency.objects.get(slug='department-of-homeland-security')
-        add_reading_rooms(agency, reading_room_data)
+        update_reading_rooms(agency, reading_room_data)
         agency.save()
 
         # Retrieve saved
@@ -192,7 +192,7 @@ class LoadingTest(TestCase):
             'reading_rooms': [
                 ['Url One', 'http://urlone.gov'],
                 ['Url Two', 'http://urltwo.gov']]}
-        add_reading_rooms(census, data)
+        update_reading_rooms(census, data)
         all_rooms = census.reading_room_urls.all()
         self.assertEqual(2, len(all_rooms))
 
@@ -200,11 +200,9 @@ class LoadingTest(TestCase):
             'reading_rooms': [
                 ['Url One', 'http://urlone.gov'],
                 ['Url Three', 'http://urlthree.gov']]}
-        add_reading_rooms(census, data)
+        update_reading_rooms(census, data)
         rr_count = census.reading_room_urls.all().count()
         self.assertEqual(2, rr_count)
-
-
 
     def test_add_stats(self):
         """

--- a/foia_hub/tests/test_views.py
+++ b/foia_hub/tests/test_views.py
@@ -214,14 +214,22 @@ class ContactPageTests(TestCase):
         self.assertTrue('Request online' not in content)
 
     def test_reading_rooms(self):
-        rone = ReadingRoomUrls(link_text='Url One', url='http://urlone.gov')
-        rone.save()
-        rtwo = ReadingRoomUrls(link_text='Url Two', url='http://urltwo.gov')
-        rtwo.save()
-
         census = Office.objects.get(
             slug='department-of-commerce--census-bureau')
-        census.reading_room_urls.add(rone, rtwo)
+
+        rone = ReadingRoomUrls(
+            content_object=census,
+            link_text='Url One',
+            url='http://urlone.gov')
+        rone.save()
+
+        rtwo = ReadingRoomUrls(
+            content_object=census,
+            link_text='Url Two',
+            url='http://urltwo.gov')
+        rtwo.save()
+
+        #census.reading_room_urls.add(rone, rtwo)
 
         response = self.client.get(
             reverse(

--- a/foia_hub/tests/test_views.py
+++ b/foia_hub/tests/test_views.py
@@ -229,8 +229,6 @@ class ContactPageTests(TestCase):
             url='http://urltwo.gov')
         rtwo.save()
 
-        #census.reading_room_urls.add(rone, rtwo)
-
         response = self.client.get(
             reverse(
                 'contact_landing',

--- a/foia_hub/wsgi.py
+++ b/foia_hub/wsgi.py
@@ -6,7 +6,6 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.6/howto/deployment/wsgi/
 """
-import newrelic.agent
 import os
 from django.core.wsgi import get_wsgi_application
 from dj_static import Cling
@@ -14,6 +13,7 @@ from dj_static import Cling
 from foia_hub.settings.base import BASE_DIR
 
 if os.getenv("NEW_RELIC_LICENSE_KEY"):
+    import newrelic.agent
     newrelic.agent.initialize(os.path.join(
         BASE_DIR, 'newrelic.ini'))
 


### PR DESCRIPTION
There are remnant reading rooms left behind when we start doing sequences of adds-deletes. There are probably more complicated ways of solving this. I'm choosing to change how reading rooms are stored, and then changing how they are loaded to ensure we don't run into issues during loading. 

Finally, I'll add some testing around this. I picked up the changes here: https://github.com/18F/foia-hub/pull/565


