### PR TITLE
changing New Relic settings

### DIFF
--- a/cloudfoundry.md
+++ b/cloudfoundry.md
@@ -130,6 +130,8 @@ cf set-env foia DATABASE_URL [value]
 cf set-env foia FOIA_ANALYTICS_ID [value]
 cf set-env foia FOIA_SECRET_SESSION_KEY [value]
 cf set-env foia DJANGO_SETTINGS_MODULE foia_hub.settings.dev
+cf set-env foia NEW_RELIC_LICENSE_KEY=[value]
+cf set-env foia NEW_RELIC_APP_NAME=[value]
 ```
 
 * Moved the runtime down from `3.4.2` to `3.4.0`, as that's what 18F's CF currently supports.

--- a/env.example
+++ b/env.example
@@ -1,5 +1,5 @@
 # Copy this file to .env so that you can use tools like foreman or autoenv to
-# manage these environment variables. 
+# manage these environment variables.
 
 # Which environment? (defaults to development)
 DJANGO_SETTINGS_MODULE=foia_hub.settings.dev
@@ -24,13 +24,13 @@ DATABASE_URL="postgres://username:password@host:5432/databasename"
 
 
 # If you use an S3 bucket for serving static files in production, you'll need
-# some credentials. 
+# some credentials.
 FOIA_AWS_ACCESS_KEY_ID="CHANGE THIS"
 FOIA_AWS_SECRET_ACCESS_KEY="CHANGE THIS"
 
 
 # New Relic Key and Toggle, if there is a key New Relic will run
-# You'll need to install the New Relic agent available here: 
+# You'll need to install the New Relic agent available here:
 # https://docs.newrelic.com/docs/agents/python-agent/getting-started/python-agent-quick-start
-
+# NEW_RELIC_APP_NAME=`app name`
 # NEW_RELIC_LICENSE_KEY=`licence key`

--- a/foia_hub/newrelic.ini
+++ b/foia_hub/newrelic.ini
@@ -33,7 +33,7 @@
 # application as you would like it to show up in New Relic UI.
 # The UI will then auto-map instances of your application into a
 # entry on your home dashboard page.
-app_name = openFOIA
+# app_name = In $NEW_RELIC_APP_NAME
 
 # When "true", the agent collects performance data about your
 # application and reports this data to the New Relic UI at


### PR DESCRIPTION
App names should be set in env variables to help differentiate each app. I've set the following env variables in AWS and CF

CF
foia ---> foia-cf
foia-a ---> foia-a-cf
foia-b ---> foia-b-cf

AWS
foia ---> foia-aws

Once we merge this PR and reset the apps the names above should appear on New Relic. 