### PR TITLE
Add 404 and 500 error templates

### DIFF
--- a/foia_hub/templates/404.html
+++ b/foia_hub/templates/404.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+
+{% block body %}
+<div class="container">
+    <section class="content">
+        <h1> 404. Not Found. </h1>
+
+        <p> 
+            We're sorry, we could not find the page you're looking for. Please make sure the URL is correct. 
+        </p>
+
+        <p>
+            If you're looking for an agency, try searching by name, acronym or topic:
+        </p>
+        <p>
+            <form id="search" method="get" action="/agencies">
+                <input id="query" name="query" type="search">
+                <input class="submit" type="submit" value="Search">
+            </form>
+        </p>
+    </section>
+</div>
+{% endblock %}

--- a/foia_hub/templates/500.html
+++ b/foia_hub/templates/500.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block body %}
+<div class="container">
+    <section class="content">
+        <h1> 500. Error. </h1>
+
+        <p> 
+            Looks like something went wrong. 
+        </p>
+
+        <p>
+            Please go back and try again, or try reloading this page. 
+        </p>
+    </section>
+</div>
+{% endblock %}


### PR DESCRIPTION
In this pull request, I add extremely basic 404 and 500 error templates - mostly as placeholders while we figure out a proper design and experience for these. 

The 404 template contains a search bar (not styled, no auto-complete) as an example of the sort of thing we could do here. 