### PR TITLE
Add the site to the DAP

### DIFF
--- a/foia_hub/templates/base.html
+++ b/foia_hub/templates/base.html
@@ -54,5 +54,9 @@
   ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
 </script>
+
+<!-- report to the DAP at https://analytics.usa.gov -->
+<script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
This adds the site to the Digital Analytics Program, which includes participation in the [public dashboard](https://analytics.usa.gov/).