### PR TITLE
Banner close on tab+enter

### DIFF
--- a/foia_hub/static/js/main.js
+++ b/foia_hub/static/js/main.js
@@ -30,6 +30,9 @@ Utils = {
 };
 
 $(document).ready(function(){
+    // if this browser supports localstorage, check for the value
+    // that gets set to keep the banner closed once a user has clicked
+    // the close button. if not present, show the banner.
     if (window.localStorage !== 'undefined') {
         if (window.localStorage.getItem('keep-banner-closed') !== '1') {
             $('#notice').removeClass('hidden');
@@ -38,6 +41,9 @@ $(document).ready(function(){
     $("#notice--close").click(function(){
         $("#notice").slideUp();
 
+        // when a user clicks or tabs to and hits enter on the banner 
+        // close button, set a local storage value that gets checked
+        // on page load and determines whether banner is shown
         if (window.localStorage !== 'undefined') {
             window.localStorage.setItem('keep-banner-closed', '1');
         }

--- a/foia_hub/static/js/main.js
+++ b/foia_hub/static/js/main.js
@@ -30,6 +30,8 @@ Utils = {
 };
 
 $(document).ready(function(){
+    var $bannerCloseButton = $("#notice--close");
+
     // if this browser supports localstorage, check for the value
     // that gets set to keep the banner closed once a user has clicked
     // the close button. if not present, show the banner.
@@ -38,7 +40,7 @@ $(document).ready(function(){
             $('#notice').removeClass('hidden');
         }
     }
-    $("#notice--close").click(function(){
+    $bannerCloseButton.click(function(){
         $("#notice").slideUp();
 
         // when a user clicks or tabs to and hits enter on the banner 
@@ -46,6 +48,11 @@ $(document).ready(function(){
         // on page load and determines whether banner is shown
         if (window.localStorage !== 'undefined') {
             window.localStorage.setItem('keep-banner-closed', '1');
+        }
+    });
+    $bannerCloseButton.keypress(function(e){
+        if (e.which === 13) {
+            $(e.target).click();
         }
     });
     $("#notice--toggle").click(function(){

--- a/foia_hub/static/js/main.js
+++ b/foia_hub/static/js/main.js
@@ -53,6 +53,7 @@ $(document).ready(function(){
     // if someone tabs to the close button and hits enter, trigger
     // a click event
     $bannerCloseButton.keypress(function(e){
+        // no need to check for e.keyCode vs e.which, jQuery fills which
         if (e.which === 13) {
             $(e.target).click();
         }


### PR DESCRIPTION
**Should be merged prior to https://github.com/18F/foia-hub/pull/725 for ease.**

Adds commenting around banner persistence and makes it so that if you tab to the close button and hit enter, the banner will shut.

Note that if you click or tab+enter on the button accidentally, it may not be clear how to reopen it? That is likely an enhancement to consider another time.