### PR TITLE
Use gunicorn instead of waitress

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: waitress-serve --port=$VCAP_APP_PORT foia_hub.wsgi:application
+web: gunicorn foia_hub.wsgi:application --log-file -

--- a/cf.sh
+++ b/cf.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "------ Starting APP ------"
-waitress-serve --port=$VCAP_APP_PORT foia_hub.wsgi:application
+gunicorn foia_hub.wsgi:application --log-file -

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 # all applications use these settings and services
-memory: 1G
+memory: 512mb
 instances: 1
 applications:
 - name: foia


### PR DESCRIPTION
We should set a `WEB_CONCURRENCY` env variable to `3` on each of the apps.