### PR TITLE
Reduce the memory configuration by this instance

### DIFF
--- a/staging-manifest.yml
+++ b/staging-manifest.yml
@@ -1,6 +1,6 @@
 ---
 # all applications use these settings and services
-memory: 1G
+memory: 512m
 instances: 1
 applications:
 - name: openfoia-staging


### PR DESCRIPTION
We reduced the memory configuration of  the production instances. Doing the same for staging. 