### PR TITLE
Remove URL for admin, as we do not use it

### DIFF
--- a/foia_hub/urls.py
+++ b/foia_hub/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import patterns, include, url
 from django.conf import settings  # For debugging.
-from django.contrib import admin
 from django.views.generic import TemplateView
 
 from foia_hub.views import (
@@ -51,12 +50,6 @@ urlpatterns += patterns(
     url(r'^update-contacts/', include(contact_updater_urls)),
 )
 
-# Admin
-admin.autodiscover()
-urlpatterns += patterns(
-    '',
-    url(r'^admin/', include(admin.site.urls)),
-)
 
 # For development
 if settings.DEBUG:


### PR DESCRIPTION
We don't use the admin interface. Because of Jinja related weirdness, going to /admin was throwing an exception. It's better to simply disable the admin urls for now, and show a more appropriate 404. 