### PR TITLE
Fix URL for foia.gov

### DIFF
--- a/foia_hub/templates/includes/nav.html
+++ b/foia_hub/templates/includes/nav.html
@@ -8,7 +8,7 @@
       <div class="usa--content">
         <span class="official"><img alt="US flag signifying that this is a United States Federal Government website" src="{{ static("images/us_flag_small.png")}}" class="flag">&nbsp;&nbsp;An official website of the U.S. Government</span>
         <span class="alpha">This website is in development. <a id="notice--toggle" href="#">Learn more</a></span>
-        <span class="foiagov"><a href="///www.foia.gov">Go to FOIA.gov</a></span>
+        <span class="foiagov"><a href="http://www.foia.gov">Go to FOIA.gov</a></span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The URL for foia.gov in the nav bar was not formatted correctly. Chrome would resolve this to an https url. foia.gov does not have https. 
