### PR TITLE
cleaning load_agency_contacts

### DIFF
--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -3,7 +3,6 @@
 import logging
 import os
 import string
-import sys
 
 import yaml
 from glob import iglob

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -73,6 +73,8 @@ def add_request_time_statistics(data, agency, office=None):
     stats = Stats.objects.filter(agency__name=agency.name)
     if office:
         stats = stats.filter(office__name=office.name)
+    else:
+        stats = stats.filter(office__isnull=True)
     stats.delete()
 
     if data.get('request_time_stats'):

--- a/foia_hub/scripts/load_agency_contacts.py
+++ b/foia_hub/scripts/load_agency_contacts.py
@@ -15,21 +15,6 @@ django.setup()
 logger = logging.getLogger(__name__)
 
 
-def check_urls(agency_url, row, field):
-    # Because only some rows have websites, we only want to update if they do.
-    row_url = row.get(field, None)
-    # Check if the existing rec has a url & if it doesn't
-    # match, then we end up with two conflicting records.
-    # In this case, we need to reaccess website on agency.
-    if agency_url and (agency_url != row_url):
-        logger.warning('Two records with the same agency have two diff urls.')
-        logger.warning('1:%s | 2:%s' % (agency_url, row_url))
-        logger.warning('Website: %s, was not saved.' % (row_url))
-        return agency_url
-    else:
-        return row_url
-
-
 def extract_tty_phone(service_center):
     """ Extract a TTY phone number if one exists from the service_center
     entry in the YAML. """
@@ -210,27 +195,3 @@ def process_yamls(folder):
     for item in iglob(os.path.join(folder, '*.yaml')):
         data = yaml.load(open(item))
         load_data(data)
-
-if __name__ == "__main__":
-
-    '''
-        To run this:
-        python load_agency_contacts $LOCATION_OF_DATA
-
-        The data is currently is a folder of yaml that is in the main
-        foia repo. If you were running this locally, it might look something
-        like this:
-
-        python load_agency_contacts.py ~/Projects/code/foia/foia/contacts/data
-
-        # If you want to designate an alternate csv path, specify that as the
-        # next argument following the yaml dir otherwise
-        # the script will default
-        # to the following:
-
-        # ../../data/foia-contacts/full-foia-contacts/
-
-    '''
-
-    yaml_folder = sys.argv[1]
-    process_yamls(yaml_folder)

--- a/foia_hub/tests/test_loading.py
+++ b/foia_hub/tests/test_loading.py
@@ -209,7 +209,7 @@ class LoadingTest(TestCase):
         rr_count = census.reading_room_urls.all().count()
         self.assertEqual(2, rr_count)
 
-    def test_add_stats(self):
+    def test_add_agency_stats(self):
         """
         Confirms all latest records are loaded, no empty records
         are created, and records with a value of `less than one`
@@ -246,6 +246,29 @@ class LoadingTest(TestCase):
 
         # Verify latest old data is overwritten when new data is updated
         self.assertEqual(len(agency.stats_set.all()), 2)
+
+    def test_add_office_stats(self):
+        """ Check that office stats are added correctly and verify that adding
+        Agency stats after office stats does not delete office stats."""
+
+        # Adding office stats
+        agency = Agency.objects.get(slug='department-of-homeland-security')
+        slug = 'department-of-homeland-security--'
+        slug += 'federal-emergency-management-agency'
+        office = Office.objects.get(slug=slug)
+        data = {'request_time_stats': {
+            '2015': {'simple_median_days': '3',
+                     'complex_median_days': '3'}}}
+        add_request_time_statistics(data, agency, office)
+        self.assertEqual(len(office.stats_set.all()), 2)
+
+        # Adding agency stats
+        data = {'request_time_stats': {
+            '2015': {'simple_median_days': '300',
+                     'complex_median_days': '300'}}}
+        add_request_time_statistics(data, agency, office)
+        self.assertEqual(len(agency.stats_set.all()), 2)
+        self.assertEqual(len(office.stats_set.all()), 2)
 
     def test_extract_tty_phone(self):
         """ Test: from a service center entry, extract the TTY phone if it


### PR DESCRIPTION
I ran the tests with coverage to look for testing gaps. Changes:
The `check_urls ` function isn't used so I removed it along with anything below the `-if __name__ == "__main__":` statement. 

I also realized that we didn't test adding office stats so I added an additional test and found a possible edge case the might cause office stats to not update. 