### PR TITLE
Removing styling from error messages, but keeping position

### DIFF
--- a/foia_hub/static/js/contact-updater/form-controls.js
+++ b/foia_hub/static/js/contact-updater/form-controls.js
@@ -4,7 +4,7 @@ $(function(){
 });
 
 jQuery(function ($) {
-    $('form').validatr();
+    $('form').validatr({'theme': 'custom'});
 });
 
 $('form').validatr('addTest', {


### PR DESCRIPTION
New error messages 
```html
<div class="validatr-message custom" style="position: absolute; top: 500.9375px; left: 323.171875px;">Please fill out this field.</div>
```