### PR TITLE
Update to new DAP snippet, add forceSSL

### DIFF
--- a/foia_hub/templates/base.html
+++ b/foia_hub/templates/base.html
@@ -56,11 +56,12 @@
 
   ga('create', '{{ ANALYTICS_ID }}', 'auto');
   ga('set', 'anonymizeIp', true);
+  ga('set', 'forceSSL', true);
   ga('send', 'pageview');
 </script>
 
-<!-- report to the DAP at https://analytics.usa.gov -->
-<script id="_fed_an_ua_tag" src="https://analytics.usa.gov/dap/dap.min.js?agency=DOJ"></script>
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOJ"></script>
 
 </body>
 </html>


### PR DESCRIPTION
This changes the DAP embed code to:

```
<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOJ"></script>
```

This takes advantage of the DAP's new [centrally hosted JavaScript code](https://www.digitalgov.gov/2015/08/14/secure-central-hosting-for-the-digital-analytics-program/), which means 18f.gsa.gov will automatically get security updates, new features, and other bugfixes automatically.