### PR TITLE
Remove 18f-foia@gsa.gov email

### DIFF
--- a/contact_updater/templates/validated.html
+++ b/contact_updater/templates/validated.html
@@ -3,7 +3,7 @@
     <li>Make sure that all the updated information is correct. The contact information you have entered will appear on your agency’s page. </li>
     <li>Download the contact_data.json file.</li>
     <li>Agency web managers will need to place the contact_data.json file in the <code>/foia/quarterly/</code> directory of the agency's website. For example, the Department of Justice will place its file at <code>www.justice.gov/foia/quarterly/contact_data.json</code>. In some cases, the <code>/foia/quarterly/</code> directory may not yet exist, and web managers will first need to create it.</li>
-    <li>Within 2 days your updates should appear on your agency’s page. Please double-check to make sure your changes have been implemented. If not, please email us at <a href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a></li>
+    <li>Within 2 days your updates should appear on your agency’s page. Please double-check to make sure your changes have been implemented.</li>
 </ol>
 {# Invisible form to store data while validated this allows the user to
  not have data deleted #}

--- a/foia_hub/templates/about.html
+++ b/foia_hub/templates/about.html
@@ -38,14 +38,6 @@
                 development, which means our site might not have every feature
                 you're looking for.</p>
 
-                <p>Please let us know what's working and what you'd like to see
-                in the future - we're actively improving openFOIA, and we base
-                our improvements on feedback from users like you! Email your
-                suggestions to <a
-                href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a>, or visit
-                our <a href="https://github.com/18F/foia-hub/issues">issue
-                tracker here</a>.</p>
-
                 <p>Developers should check out the <a
                 href="{{url('developers')}}">developer resources page</a>.</p>
             </section>

--- a/foia_hub/templates/contacts/profile.html
+++ b/foia_hub/templates/contacts/profile.html
@@ -174,11 +174,5 @@
 
     </div>
   </section><!--/department-->
-
-  <section class="inaccurate">
-    <p>
-      Inaccurate information here? Email us at <a class='inaccurateinfo--email' href="mailto:18f-foia@gsa.gov?subject=Inaccurate information for {{profile.slug}}">18f-foia@gsa.gov</a> so we can fix it.
-    </p>
-  </section>
 </div>
 {% endblock %}

--- a/foia_hub/templates/includes/nav.html
+++ b/foia_hub/templates/includes/nav.html
@@ -12,15 +12,6 @@
       </div>
     </div>
   </div>
-  <div id="notice" class="hidden">
-    <div class="container">
-      <div id="notice--close" tabindex="0" aria-label='Select to hide banner'><i class="fa fa-times"></i></div>
-      <div class="notice--content">
-        <h2>This site is in development. Tell us what you think!</h2>
-        <p>We're working hard to make openFOIA a useful addition to the resources available at <a href="http://foia.gov">FOIA.gov</a>. Your feedback is important to us as we build this site. Email <a href="mailto:18f-foia@gsa.gov">18f-foia@gsa.gov</a> and let us know how it's working for you.</p>
-      </div>
-    </div>
-  </div>
   <div id="topnav">
     <div class="container">
       <div id="logo">

--- a/foia_hub/tests/test_views.py
+++ b/foia_hub/tests/test_views.py
@@ -178,15 +178,6 @@ class AgenciesPageTests(TestCase):
 class ContactPageTests(TestCase):
     fixtures = ['agencies_test.json', 'offices_test.json']
 
-    def test_inaccurate_contact(self):
-        response = self.client.get(
-            reverse(
-                'contact_landing',
-                args=['department-of-commerce--census-bureau']))
-        self.assertTrue(200, response.status_code)
-        content = response.content.decode('utf-8')
-        self.assertTrue('18f-foia@gsa.gov' in content)
-
     def test_no_email(self):
         """ For agencies without their own request form, and without an email
         address, do not display a FOIA request form. """


### PR DESCRIPTION
The site is not maintained or responsive to public feedback at the `18f-foia@gsa.gov` email address displayed, so it should be removed. The email alias will be closed down.