### PR TITLE
Create .about.yml

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -1,0 +1,30 @@
+---
+project: FOIA Modernization
+name: foia
+github:
+- 18F/foia
+- 18F/foia-hub
+description: A new tool to search for the correct agency or office to make a FOIA
+  request.
+partners:
+- Department of Justice
+- FOIA agency task force
+impact: The U.S. Federal Government processed nearly 700,000 FOIA requests in fiscal
+  year 2013.
+stage: alpha
+milestones:
+- 'June 2014: Project Discovery stage started'
+- 'April 2015: open.foia.gov is deployed. '
+contact:
+- 18f/foia/issues
+stack: python, django
+team: jackie, khandelwal, majma, eric, gramirez, jtag, victor, erica
+licenses:
+  foia: Public Domain (CC0)
+  foia-hub: Public Domain (CC0)
+licenselink: 18F/foia/blob/master/LICENSE.md
+links:
+- https://trello.com/b/D0r2UOz0/foia-scrum-board
+blog:
+- foia
+status: 


### PR DESCRIPTION
As we scale out the [about.yml](https://github.com/18f/about_yml) standard on projects, we need to relocates the yml file for this project from [here](https://github.com/18F/data-private/blob/master/projects/foia.yml) to the primary project repo.