### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,7 +5,7 @@
 DJANGO_SETTINGS_MODULE=foia_hub.settings.dev
 
 # Use with foreman or CloudFoundry.
-VCAP_APP_PORT=8000
+PORT=8000
 
 # Change this in production.
 FOIA_SECRET_SESSION_KEY="CHANGE THIS"


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.